### PR TITLE
Use solar zenith angle from MAPL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+### Changed
+### Fixed
+### Removed
+### Deprecated
+
+## [next release]
 
 ### Changed
 
-### Fixed
-
-### Removed
-
-### Deprecated
+- Instead of calling the GMI routine for Solar Zenith Angle, now call a wrapper for the MAPL version
 
 ## [1.0.0] - 2023-01-18
 


### PR DESCRIPTION
TR now calls a new wrapper (for getting SZA from MAPL) for all passive tracers using GMI dry deposition (e.g. Be7, Be10, Pb210). It is slightly non-zero-diff for these tracers.

This PR is zero-diff for the 4 tracers that are automatically configured to run by the 'setup' scripts.

This PR goes together with changes in the Chemistry and GMI repo's.
https://github.com/GEOS-ESM/GEOSchem_GridComp/pull/255#issue-1639901226
https://github.com/GEOS-ESM/GMI/pull/3#issue-1639822678