### PR TITLE
merge dev to main for v1.1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 # Anchors to prevent forgetting to update a version
-baselibs_version: &baselibs_version v7.7.0
-bcs_version: &bcs_version v10.23.0
+baselibs_version: &baselibs_version v7.13.0
+bcs_version: &bcs_version v11.00.0
 
 orbs:
   ci: geos-esm/circleci-tools@1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+### Changed
+### Fixed
+### Removed
+### Deprecated
+
+## [next release]
 
 ### Changed
 
-### Fixed
-
-### Removed
-
-### Deprecated
+- Instead of calling the GMI routine for Solar Zenith Angle, now call a wrapper for the MAPL version
 
 ## [1.0.0] - 2023-01-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Deprecated
 
-## [next release]
+## [1.1.0] - 2023-06-09
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Instead of calling the GMI routine for Solar Zenith Angle, now call a wrapper for the MAPL version
+- Update CI to use Baselibs 7.13.0
 
 ## [1.0.0] - 2023-01-18
 


### PR DESCRIPTION
Copying notes from 'develop':
TR now calls a new wrapper (for getting SZA from MAPL) for all passive tracers using GMI dry deposition (e.g. Be7, Be10, Pb210). It is slightly non-zero-diff for these tracers.

This PR is zero-diff for the 4 tracers that are automatically configured to run by the 'setup' scripts.
It is non-zero-diff for Pb210, which is included in R21C.

Also, CI uses new BASELIBS.

This code requires CHEMISTRY release v1.13.1 or later