### PR TITLE
Change Be and Pb to use GOCART convection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reformatted the YAML ExtData file, zero diff
 
 ### Fixed
+
+- Bug fix for GMI dry deposition, related to solar zenith angle
+
 ### Removed
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Reformatted the YAML ExtData file, zero diff
+- Changed Be and Pb species to use GOCART convection (instead of MOIST), and GOCART approach (instead of GMI) for settling, dry dep and wet removal
 
 ### Fixed
 

--- a/TR_GridComp---Be10.rc
+++ b/TR_GridComp---Be10.rc
@@ -37,44 +37,44 @@
 
 # DEPOSITION
 # ---------------------------
-  GMI_dry_deposition: TRUE
-# (as in gmi_aerosol.h)
-  GMI_aerosol_density: 1769.e0
-  GMI_effective_radius: 0.1000e-6
-  GMI_c1: 0.4809e0
-  GMI_c2: 3.082e0
-  GMI_c3: 3.110e-11
-  GMI_c4: -1.428e0
-  GMI_hstar_dry:           0.0e0  # as in setkin_depos.h
-  GMI_delH_298_over_R_dry: 0.0e0  # as in setkin_depos.h
+#  GMI_dry_deposition: TRUE
+## (as in gmi_aerosol.h)
+#  GMI_aerosol_density: 1769.e0
+#  GMI_effective_radius: 0.1000e-6
+#  GMI_c1: 0.4809e0
+#  GMI_c2: 3.082e0
+#  GMI_c3: 3.110e-11
+#  GMI_c4: -1.428e0
+#  GMI_hstar_dry:           0.0e0  # as in setkin_depos.h
+#  GMI_delH_298_over_R_dry: 0.0e0  # as in setkin_depos.h
+#
+## NOTE: must provide for GMI dry dep and wet dep
+#  mw: 10.0
+#  GMI_treat_as_aerosol: TRUE     # as in setkin_depos.h
+#  GMI_f0:                  0.0e0  # as in setkin_depos.h  (oxidize)
+#
+#  GMI_wet_removal: TRUE
+#  GMI_rel_scav_eff:        1.0e0  # as in gmi_aerosol.h
+#  GMI_retention_eff:       0.0e0  # as in setkin_depos.h
+#  GMI_treat_as_h2o2:    FALSE
+#  GMI_treat_as_hno3:    FALSE
+#  GMI_hstar_wet:           0.0e0  # as in setkin_depos.h
+#  GMI_delH_298_over_R_wet: 0.0e0  # as in setkin_depos.h
 
-# NOTE: must provide for GMI dry dep and wet dep
   mw: 10.0
-  GMI_treat_as_aerosol: TRUE     # as in setkin_depos.h
-  GMI_f0:                  0.0e0  # as in setkin_depos.h  (oxidize)
 
-  GMI_wet_removal: TRUE
-  GMI_rel_scav_eff:        1.0e0  # as in gmi_aerosol.h
-  GMI_retention_eff:       0.0e0  # as in setkin_depos.h
-  GMI_treat_as_h2o2:    FALSE
-  GMI_treat_as_hno3:    FALSE
-  GMI_hstar_wet:           0.0e0  # as in setkin_depos.h
-  GMI_delH_298_over_R_wet: 0.0e0  # as in setkin_depos.h
+  GOCART_wet_removal: TRUE
+  GOCART_convection:  TRUE
 
-# mw: 10.0
+  GOCART_species:     Be10
+  GOCART_aero_flag:   TRUE
+  GOCART_fscav:       0.4    # (what value should be used?)  scavenging efficiency in convective updrafts [km-1]
+  GOCART_fwet:        1.0    # (what value should be used?)  large-scale wet removal efficiency [fraction]
 
-# GOCART_wet_removal: TRUE
-# GOCART_convection:  FALSE
+  GOCART_settling:    FALSE
+  GOCART_radius:      0.35e-6  # (what value should be used?)  radius for settling [m]
+  GOCART_rho_p:       1800.0   # (what value should be used?)  density for setting [kg m-3]
+  GOCART_rh_effect:   0        # (what value should be used?)  Flag for RH effects  (0=none, 1=Fitzgerald, 2=Gerber, 3=Ammonium Sulfate, 4=Petters and Kreidenweis)
 
-# GOCART_species:     Be10
-# GOCART_aero_flag:   TRUE
-# GOCART_fscav:       0.4    # (what value should be used?)  scavenging efficiency in convective updrafts [km-1]
-# GOCART_fwet:        1.0    # (what value should be used?)  large-scale wet removal efficiency [fraction]
-
-# GOCART_settling:    FALSE
-# GOCART_radius:      0.35e-6  # (what value should be used?)  radius for settling [m]
-# GOCART_rho_p:       1800.0   # (what value should be used?)  density for setting [kg m-3]
-# GOCART_rh_effect:   0        # (what value should be used?)  Flag for RH effects  (0=none, 1=Fitzgerald, 2=Gerber, 3=Ammonium Sulfate, 4=Petters and Kreidenweis)
-
-# GOCART_dry_deposition:    TRUE
+  GOCART_dry_deposition:    TRUE
 

--- a/TR_GridComp---Be10s.rc
+++ b/TR_GridComp---Be10s.rc
@@ -37,44 +37,44 @@
 
 # DEPOSITION
 # ---------------------------
-  GMI_dry_deposition: TRUE
-# (as in gmi_aerosol.h)
-  GMI_aerosol_density: 1769.e0
-  GMI_effective_radius: 0.1000e-6
-  GMI_c1: 0.4809e0
-  GMI_c2: 3.082e0
-  GMI_c3: 3.110e-11
-  GMI_c4: -1.428e0
-  GMI_hstar_dry:           0.0e0  # as in setkin_depos.h
-  GMI_delH_298_over_R_dry: 0.0e0  # as in setkin_depos.h
+#  GMI_dry_deposition: TRUE
+## (as in gmi_aerosol.h)
+#  GMI_aerosol_density: 1769.e0
+#  GMI_effective_radius: 0.1000e-6
+#  GMI_c1: 0.4809e0
+#  GMI_c2: 3.082e0
+#  GMI_c3: 3.110e-11
+#  GMI_c4: -1.428e0
+#  GMI_hstar_dry:           0.0e0  # as in setkin_depos.h
+#  GMI_delH_298_over_R_dry: 0.0e0  # as in setkin_depos.h
+#
+## NOTE: must provide for GMI dry dep and wet dep
+#  mw: 10.0
+#  GMI_treat_as_aerosol: TRUE     # as in setkin_depos.h
+#  GMI_f0:                  0.0e0  # as in setkin_depos.h  (oxidize)
+#
+#  GMI_wet_removal: TRUE
+#  GMI_rel_scav_eff:        1.0e0  # as in gmi_aerosol.h
+#  GMI_retention_eff:       0.0e0  # as in setkin_depos.h
+#  GMI_treat_as_h2o2:    FALSE
+#  GMI_treat_as_hno3:    FALSE
+#  GMI_hstar_wet:           0.0e0  # as in setkin_depos.h
+#  GMI_delH_298_over_R_wet: 0.0e0  # as in setkin_depos.h
 
-# NOTE: must provide for GMI dry dep and wet dep
   mw: 10.0
-  GMI_treat_as_aerosol: TRUE     # as in setkin_depos.h
-  GMI_f0:                  0.0e0  # as in setkin_depos.h  (oxidize)
 
-  GMI_wet_removal: TRUE
-  GMI_rel_scav_eff:        1.0e0  # as in gmi_aerosol.h
-  GMI_retention_eff:       0.0e0  # as in setkin_depos.h
-  GMI_treat_as_h2o2:    FALSE
-  GMI_treat_as_hno3:    FALSE
-  GMI_hstar_wet:           0.0e0  # as in setkin_depos.h
-  GMI_delH_298_over_R_wet: 0.0e0  # as in setkin_depos.h
+  GOCART_wet_removal: TRUE
+  GOCART_convection:  TRUE
 
-# mw: 10.0
+  GOCART_species:     Be10s
+  GOCART_aero_flag:   TRUE
+  GOCART_fscav:       0.4    # (what value should be used?)  scavenging efficiency in convective updrafts [km-1]
+  GOCART_fwet:        1.0    # (what value should be used?)  large-scale wet removal efficiency [fraction]
 
-# GOCART_wet_removal: TRUE
-# GOCART_convection:  FALSE
+  GOCART_settling:    FALSE
+  GOCART_radius:      0.35e-6  # (what value should be used?)  radius for settling [m]
+  GOCART_rho_p:       1800.0   # (what value should be used?)  density for setting [kg m-3]
+  GOCART_rh_effect:   0        # (what value should be used?)  Flag for RH effects  (0=none, 1=Fitzgerald, 2=Gerber, 3=Ammonium Sulfate, 4=Petters and Kreidenweis)
 
-# GOCART_species:     Be10s
-# GOCART_aero_flag:   TRUE
-# GOCART_fscav:       0.4    # (what value should be used?)  scavenging efficiency in convective updrafts [km-1]
-# GOCART_fwet:        1.0    # (what value should be used?)  large-scale wet removal efficiency [fraction]
-
-# GOCART_settling:    FALSE
-# GOCART_radius:      0.35e-6  # (what value should be used?)  radius for settling [m]
-# GOCART_rho_p:       1800.0   # (what value should be used?)  density for setting [kg m-3]
-# GOCART_rh_effect:   0        # (what value should be used?)  Flag for RH effects  (0=none, 1=Fitzgerald, 2=Gerber, 3=Ammonium Sulfate, 4=Petters and Kreidenweis)
-
-# GOCART_dry_deposition:    TRUE
+  GOCART_dry_deposition:    TRUE
 

--- a/TR_GridComp---Be7.rc
+++ b/TR_GridComp---Be7.rc
@@ -37,44 +37,44 @@
 
 # DEPOSITION
 # ---------------------------
-  GMI_dry_deposition: TRUE
-# (as in gmi_aerosol.h)
-  GMI_aerosol_density: 1769.e0
-  GMI_effective_radius: 0.1000e-6
-  GMI_c1: 0.4809e0
-  GMI_c2: 3.082e0
-  GMI_c3: 3.110e-11
-  GMI_c4: -1.428e0
-  GMI_hstar_dry:           0.0e0  # as in setkin_depos.h
-  GMI_delH_298_over_R_dry: 0.0e0  # as in setkin_depos.h
+#  GMI_dry_deposition: TRUE
+## (as in gmi_aerosol.h)
+#  GMI_aerosol_density: 1769.e0
+#  GMI_effective_radius: 0.1000e-6
+#  GMI_c1: 0.4809e0
+#  GMI_c2: 3.082e0
+#  GMI_c3: 3.110e-11
+#  GMI_c4: -1.428e0
+#  GMI_hstar_dry:           0.0e0  # as in setkin_depos.h
+#  GMI_delH_298_over_R_dry: 0.0e0  # as in setkin_depos.h
+#
+## NOTE: must provide for GMI dry dep and wet dep
+#  mw: 7.0
+#  GMI_treat_as_aerosol: TRUE     # as in setkin_depos.h
+#  GMI_f0:                  0.0e0  # as in setkin_depos.h  (oxidize)
+#
+#  GMI_wet_removal: TRUE
+#  GMI_rel_scav_eff:        1.0e0  # as in gmi_aerosol.h
+#  GMI_retention_eff:       0.0e0  # as in setkin_depos.h
+#  GMI_treat_as_h2o2:    FALSE
+#  GMI_treat_as_hno3:    FALSE
+#  GMI_hstar_wet:           0.0e0  # as in setkin_depos.h
+#  GMI_delH_298_over_R_wet: 0.0e0  # as in setkin_depos.h
 
-# NOTE: must provide for GMI dry dep and wet dep
   mw: 7.0
-  GMI_treat_as_aerosol: TRUE     # as in setkin_depos.h
-  GMI_f0:                  0.0e0  # as in setkin_depos.h  (oxidize)
 
-  GMI_wet_removal: TRUE
-  GMI_rel_scav_eff:        1.0e0  # as in gmi_aerosol.h
-  GMI_retention_eff:       0.0e0  # as in setkin_depos.h
-  GMI_treat_as_h2o2:    FALSE
-  GMI_treat_as_hno3:    FALSE
-  GMI_hstar_wet:           0.0e0  # as in setkin_depos.h
-  GMI_delH_298_over_R_wet: 0.0e0  # as in setkin_depos.h
+  GOCART_wet_removal: TRUE
+  GOCART_convection:  TRUE
 
-# mw: 7.0
+  GOCART_species:     Be7
+  GOCART_aero_flag:   TRUE
+  GOCART_fscav:       0.4    # (what value should be used?)  scavenging efficiency in convective updrafts [km-1]
+  GOCART_fwet:        1.0    # (what value should be used?)  large-scale wet removal efficiency [fraction]
 
-# GOCART_wet_removal: TRUE
-# GOCART_convection:  FALSE
+  GOCART_settling:    FALSE
+  GOCART_radius:      0.35e-6  # (what value should be used?)  radius for settling [m]
+  GOCART_rho_p:       1800.0   # (what value should be used?)  density for setting [kg m-3]
+  GOCART_rh_effect:   0        # (what value should be used?)  Flag for RH effects  (0=none, 1=Fitzgerald, 2=Gerber, 3=Ammonium Sulfate, 4=Petters and Kreidenweis)
 
-# GOCART_species:     Be7
-# GOCART_aero_flag:   TRUE
-# GOCART_fscav:       0.4    # (what value should be used?)  scavenging efficiency in convective updrafts [km-1]
-# GOCART_fwet:        1.0    # (what value should be used?)  large-scale wet removal efficiency [fraction]
-
-# GOCART_settling:    FALSE
-# GOCART_radius:      0.35e-6  # (what value should be used?)  radius for settling [m]
-# GOCART_rho_p:       1800.0   # (what value should be used?)  density for setting [kg m-3]
-# GOCART_rh_effect:   0        # (what value should be used?)  Flag for RH effects  (0=none, 1=Fitzgerald, 2=Gerber, 3=Ammonium Sulfate, 4=Petters and Kreidenweis)
-
-# GOCART_dry_deposition:    TRUE
+  GOCART_dry_deposition:    TRUE
 

--- a/TR_GridComp---Be7s.rc
+++ b/TR_GridComp---Be7s.rc
@@ -37,44 +37,44 @@
 
 # DEPOSITION
 # ---------------------------
-  GMI_dry_deposition: TRUE
-# (as in gmi_aerosol.h)
-  GMI_aerosol_density: 1769.e0
-  GMI_effective_radius: 0.1000e-6
-  GMI_c1: 0.4809e0
-  GMI_c2: 3.082e0
-  GMI_c3: 3.110e-11
-  GMI_c4: -1.428e0
-  GMI_hstar_dry:           0.0e0  # as in setkin_depos.h
-  GMI_delH_298_over_R_dry: 0.0e0  # as in setkin_depos.h
+#  GMI_dry_deposition: TRUE
+## (as in gmi_aerosol.h)
+#  GMI_aerosol_density: 1769.e0
+#  GMI_effective_radius: 0.1000e-6
+#  GMI_c1: 0.4809e0
+#  GMI_c2: 3.082e0
+#  GMI_c3: 3.110e-11
+#  GMI_c4: -1.428e0
+#  GMI_hstar_dry:           0.0e0  # as in setkin_depos.h
+#  GMI_delH_298_over_R_dry: 0.0e0  # as in setkin_depos.h
+#
+## NOTE: must provide for GMI dry dep and wet dep
+#  mw: 7.0
+#  GMI_treat_as_aerosol: TRUE     # as in setkin_depos.h
+#  GMI_f0:                  0.0e0  # as in setkin_depos.h  (oxidize)
+#
+#  GMI_wet_removal: TRUE
+#  GMI_rel_scav_eff:        1.0e0  # as in gmi_aerosol.h
+#  GMI_retention_eff:       0.0e0  # as in setkin_depos.h
+#  GMI_treat_as_h2o2:    FALSE
+#  GMI_treat_as_hno3:    FALSE
+#  GMI_hstar_wet:           0.0e0  # as in setkin_depos.h
+#  GMI_delH_298_over_R_wet: 0.0e0  # as in setkin_depos.h
 
-# NOTE: must provide for GMI dry dep and wet dep
   mw: 7.0
-  GMI_treat_as_aerosol: TRUE     # as in setkin_depos.h
-  GMI_f0:                  0.0e0  # as in setkin_depos.h  (oxidize)
 
-  GMI_wet_removal: TRUE
-  GMI_rel_scav_eff:        1.0e0  # as in gmi_aerosol.h
-  GMI_retention_eff:       0.0e0  # as in setkin_depos.h
-  GMI_treat_as_h2o2:    FALSE
-  GMI_treat_as_hno3:    FALSE
-  GMI_hstar_wet:           0.0e0  # as in setkin_depos.h
-  GMI_delH_298_over_R_wet: 0.0e0  # as in setkin_depos.h
+  GOCART_wet_removal: TRUE
+  GOCART_convection:  TRUE
 
-# mw: 7.0
+  GOCART_species:     Be7s
+  GOCART_aero_flag:   TRUE
+  GOCART_fscav:       0.4    # (what value should be used?)  scavenging efficiency in convective updrafts [km-1]
+  GOCART_fwet:        1.0    # (what value should be used?)  large-scale wet removal efficiency [fraction]
 
-# GOCART_wet_removal: TRUE
-# GOCART_convection:  FALSE
+  GOCART_settling:    FALSE
+  GOCART_radius:      0.35e-6  # (what value should be used?)  radius for settling [m]
+  GOCART_rho_p:       1800.0   # (what value should be used?)  density for setting [kg m-3]
+  GOCART_rh_effect:   0        # (what value should be used?)  Flag for RH effects  (0=none, 1=Fitzgerald, 2=Gerber, 3=Ammonium Sulfate, 4=Petters and Kreidenweis)
 
-# GOCART_species:     Be7s
-# GOCART_aero_flag:   TRUE
-# GOCART_fscav:       0.4    # (what value should be used?)  scavenging efficiency in convective updrafts [km-1]
-# GOCART_fwet:        1.0    # (what value should be used?)  large-scale wet removal efficiency [fraction]
-
-# GOCART_settling:    FALSE
-# GOCART_radius:      0.35e-6  # (what value should be used?)  radius for settling [m]
-# GOCART_rho_p:       1800.0   # (what value should be used?)  density for setting [kg m-3]
-# GOCART_rh_effect:   0        # (what value should be used?)  Flag for RH effects  (0=none, 1=Fitzgerald, 2=Gerber, 3=Ammonium Sulfate, 4=Petters and Kreidenweis)
-
-# GOCART_dry_deposition:    TRUE
+  GOCART_dry_deposition:    TRUE
 

--- a/TR_GridComp---Pb210.rc
+++ b/TR_GridComp---Pb210.rc
@@ -35,44 +35,44 @@
 
 # DEPOSITION
 # ---------------------------
-  GMI_dry_deposition: TRUE
-# (as in gmi_aerosol.h)
-  GMI_aerosol_density: 1769.e0
-  GMI_effective_radius: 0.3417e-6
-  GMI_c1: 0.4809e0
-  GMI_c2: 3.082e0
-  GMI_c3: 3.110e-11
-  GMI_c4: -1.428e0
-  GMI_hstar_dry:           0.0e0  # as in setkin_depos.h
-  GMI_delH_298_over_R_dry: 0.0e0  # as in setkin_depos.h
-
-# NOTE: must provide for GMI dry dep and wet dep
-  mw: 210
-  GMI_treat_as_aerosol: TRUE     # as in setkin_depos.h
-  GMI_f0:                  0.0e0  # as in setkin_depos.h  (oxidize)
-
-  GMI_wet_removal: TRUE
-  GMI_rel_scav_eff:        1.0e0  # as in gmi_aerosol.h
-  GMI_retention_eff:       0.0e0  # as in setkin_depos.h
-  GMI_treat_as_h2o2:    FALSE
-  GMI_treat_as_hno3:    FALSE
-  GMI_hstar_wet:           0.0e0  # as in setkin_depos.h
-  GMI_delH_298_over_R_wet: 0.0e0  # as in setkin_depos.h
+#  GMI_dry_deposition: TRUE
+## (as in gmi_aerosol.h)
+#  GMI_aerosol_density: 1769.e0
+#  GMI_effective_radius: 0.3417e-6
+#  GMI_c1: 0.4809e0
+#  GMI_c2: 3.082e0
+#  GMI_c3: 3.110e-11
+#  GMI_c4: -1.428e0
+#  GMI_hstar_dry:           0.0e0  # as in setkin_depos.h
+#  GMI_delH_298_over_R_dry: 0.0e0  # as in setkin_depos.h
+#
+## NOTE: must provide for GMI dry dep and wet dep
+#  mw: 210
+#  GMI_treat_as_aerosol: TRUE     # as in setkin_depos.h
+#  GMI_f0:                  0.0e0  # as in setkin_depos.h  (oxidize)
+#
+#  GMI_wet_removal: TRUE
+#  GMI_rel_scav_eff:        1.0e0  # as in gmi_aerosol.h
+#  GMI_retention_eff:       0.0e0  # as in setkin_depos.h
+#  GMI_treat_as_h2o2:    FALSE
+#  GMI_treat_as_hno3:    FALSE
+#  GMI_hstar_wet:           0.0e0  # as in setkin_depos.h
+#  GMI_delH_298_over_R_wet: 0.0e0  # as in setkin_depos.h
 
 # NOTE: must provide mw for dry dep and wet dep
-# mw: 210
+  mw: 210
 
-# GOCART_wet_removal: TRUE
-# GOCART_convection:  FALSE
+  GOCART_wet_removal: TRUE
+  GOCART_convection:  TRUE
 
-# GOCART_species:     Pb210
-# GOCART_aero_flag:   TRUE
-# GOCART_fscav:       0.4    # (what value should be used?)  scavenging efficiency in convective updrafts [km-1]
-# GOCART_fwet:        1.0    # (what value should be used?)  large-scale wet removal efficiency [fraction]
+  GOCART_species:     Pb210
+  GOCART_aero_flag:   TRUE
+  GOCART_fscav:       0.4    # (what value should be used?)  scavenging efficiency in convective updrafts [km-1]
+  GOCART_fwet:        1.0    # (what value should be used?)  large-scale wet removal efficiency [fraction]
 
-# GOCART_settling:    FALSE
-# GOCART_radius:      0.35e-6  # (what value should be used?)  radius for settling [m]
-# GOCART_rho_p:       1800.0   # (what value should be used?)  density for setting [kg m-3]
-# GOCART_rh_effect:   0        # (what value should be used?)  Flag for RH effects  (0=none, 1=Fitzgerald, 2=Gerber, 3=Ammonium Sulfate, 4=Petters and Kreidenweis)
+  GOCART_settling:    FALSE
+  GOCART_radius:      0.35e-6  # (what value should be used?)  radius for settling [m]
+  GOCART_rho_p:       1800.0   # (what value should be used?)  density for setting [kg m-3]
+  GOCART_rh_effect:   0        # (what value should be used?)  Flag for RH effects  (0=none, 1=Fitzgerald, 2=Gerber, 3=Ammonium Sulfate, 4=Petters and Kreidenweis)
 
-# GOCART_dry_deposition:    TRUE
+  GOCART_dry_deposition:    TRUE

--- a/TR_GridComp---Pb210s.rc
+++ b/TR_GridComp---Pb210s.rc
@@ -35,45 +35,45 @@
 
 # DEPOSITION
 # ---------------------------
-  GMI_dry_deposition: TRUE
-# (as in gmi_aerosol.h)
-  GMI_aerosol_density: 1769.e0
-  GMI_effective_radius: 0.3417e-6
-  GMI_c1: 0.4809e0
-  GMI_c2: 3.082e0
-  GMI_c3: 3.110e-11
-  GMI_c4: -1.428e0
-  GMI_hstar_dry:           0.0e0  # as in setkin_depos.h
-  GMI_delH_298_over_R_dry: 0.0e0  # as in setkin_depos.h
-
-# NOTE: must provide for GMI dry dep and wet dep
-  mw: 210
-  GMI_treat_as_aerosol: TRUE     # as in setkin_depos.h
-  GMI_f0:                  0.0e0  # as in setkin_depos.h  (oxidize)
-
-  GMI_wet_removal: TRUE
-  GMI_rel_scav_eff:        1.0e0  # as in gmi_aerosol.h
-  GMI_retention_eff:       0.0e0  # as in setkin_depos.h
-  GMI_treat_as_h2o2:    FALSE
-  GMI_treat_as_hno3:    FALSE
-  GMI_hstar_wet:           0.0e0  # as in setkin_depos.h
-  GMI_delH_298_over_R_wet: 0.0e0  # as in setkin_depos.h
+#  GMI_dry_deposition: TRUE
+## (as in gmi_aerosol.h)
+#  GMI_aerosol_density: 1769.e0
+#  GMI_effective_radius: 0.3417e-6
+#  GMI_c1: 0.4809e0
+#  GMI_c2: 3.082e0
+#  GMI_c3: 3.110e-11
+#  GMI_c4: -1.428e0
+#  GMI_hstar_dry:           0.0e0  # as in setkin_depos.h
+#  GMI_delH_298_over_R_dry: 0.0e0  # as in setkin_depos.h
+#
+## NOTE: must provide for GMI dry dep and wet dep
+#  mw: 210
+#  GMI_treat_as_aerosol: TRUE     # as in setkin_depos.h
+#  GMI_f0:                  0.0e0  # as in setkin_depos.h  (oxidize)
+#
+#  GMI_wet_removal: TRUE
+#  GMI_rel_scav_eff:        1.0e0  # as in gmi_aerosol.h
+#  GMI_retention_eff:       0.0e0  # as in setkin_depos.h
+#  GMI_treat_as_h2o2:    FALSE
+#  GMI_treat_as_hno3:    FALSE
+#  GMI_hstar_wet:           0.0e0  # as in setkin_depos.h
+#  GMI_delH_298_over_R_wet: 0.0e0  # as in setkin_depos.h
 
 # NOTE: must provide mw for dry dep and wet dep
-# mw: 210
+  mw: 210
 
-# GOCART_wet_removal: TRUE
-# GOCART_convection:  FALSE
+  GOCART_wet_removal: TRUE
+  GOCART_convection:  TRUE
 
-# GOCART_species:     Pb210s
-# GOCART_aero_flag:   TRUE
-# GOCART_fscav:       0.4    # (what value should be used?)  scavenging efficiency in convective updrafts [km-1]
-# GOCART_fwet:        1.0    # (what value should be used?)  large-scale wet removal efficiency [fraction]
+  GOCART_species:     Pb210s
+  GOCART_aero_flag:   TRUE
+  GOCART_fscav:       0.4    # (what value should be used?)  scavenging efficiency in convective updrafts [km-1]
+  GOCART_fwet:        1.0    # (what value should be used?)  large-scale wet removal efficiency [fraction]
 
-# GOCART_settling:    FALSE
-# GOCART_radius:      0.35e-6  # (what value should be used?)  radius for settling [m]
-# GOCART_rho_p:       1800.0   # (what value should be used?)  density for setting [kg m-3]
-# GOCART_rh_effect:   0        # (what value should be used?)  Flag for RH effects  (0=none, 1=Fitzgerald, 2=Gerber, 3=Ammonium Sulfate, 4=Petters and Kreidenweis)
+  GOCART_settling:    FALSE
+  GOCART_radius:      0.35e-6  # (what value should be used?)  radius for settling [m]
+  GOCART_rho_p:       1800.0   # (what value should be used?)  density for setting [kg m-3]
+  GOCART_rh_effect:   0        # (what value should be used?)  Flag for RH effects  (0=none, 1=Fitzgerald, 2=Gerber, 3=Ammonium Sulfate, 4=Petters and Kreidenweis)
 
-# GOCART_dry_deposition:    TRUE
+  GOCART_dry_deposition:    TRUE
 

--- a/TR_GridCompMod.F90
+++ b/TR_GridCompMod.F90
@@ -4669,8 +4669,11 @@ CONTAINS
               radswg(:,:) = swndsrf(:,:)       ! w m^{-2}
     frictionVelocity(:,:) =   ustar(:,:)       ! m s^{-1}
 
+! SZA (don't forget to take the cosine)
+! ---
    call compute_SZA ( GC=gc, CLOCK=clock, tdt=cdt, label='TR:'//TRIM(spec%name), &
                       SZA=cosSolarZenithAngle, __RC__ )
+   cosSolarZenithAngle = COS( cosSolarZenithAngle * MAPL_DEGREES_TO_RADIANS )
 
    IF ( associated(drydep_tend_2d) ) then
      allocate( snapshot_2d( i1:i2, j1:j2), __STAT__)


### PR DESCRIPTION
Now that GOCART no longer prevents usage of the Shared convection routine, we use it for Beryllium and Lead tracers.
GMI dry deposition has been fixed (bug related to SZA), but at this point, no TR tracers use GMI dry dep by default.

This PR is zero-diff for the 4 standard tracers,  but non-zero-diff if you are running Be or Pb tracers.