### PR TITLE
Update CircleCI to use Orb v2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,11 @@
 version: 2.1
 
 # Anchors in case we need to override the defaults from the orb
-#baselibs_version: &baselibs_version v7.14.0
-#bcs_version: &bcs_version v11.1.0
+#baselibs_version: &baselibs_version v7.17.0
+#bcs_version: &bcs_version v11.4.0
 
 orbs:
-  ci: geos-esm/circleci-tools@1
+  ci: geos-esm/circleci-tools@2
 
 workflows:
   build-test:
@@ -22,4 +22,34 @@ workflows:
           repo: GEOSgcm
           checkout_fixture: true
           mepodevelop: true
-          persist_workspace: false # Needs to be true to run fv3/gcm experiment, costs extra
+          persist_workspace: true # Needs to be true to run fv3/gcm experiment, costs extra
+
+      # Run AMIP GCM (1 hour, no ExtData)
+      - ci/run_gcm:
+          name: run-GCM-on-<< matrix.compiler >>
+          context:
+            - docker-hub-creds
+          matrix:
+            parameters:
+              compiler: [gfortran, ifort]
+          requires:
+            - build-GEOSgcm-on-<< matrix.compiler >>
+          repo: GEOSgcm
+          #baselibs_version: *baselibs_version
+          #bcs_version: *bcs_version
+
+      # Run Coupled GCM (1 hour, no ExtData)
+      - ci/run_gcm:
+          name: run-coupled-GCM-on-<< matrix.compiler >>
+          context:
+            - docker-hub-creds
+          matrix:
+            parameters:
+              compiler: [gfortran, ifort]
+          requires:
+            - build-GEOSgcm-on-<< matrix.compiler >>
+          repo: GEOSgcm
+          #baselibs_version: *baselibs_version
+          #bcs_version: *bcs_version
+          gcm_ocean_type: MOM6
+          change_layout: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Update CI to use Baselibs default from the CircleCI orb
+- Update CI to use v2 orb
 - Bug fix for GMI dry deposition, related to solar zenith angle
 
 


### PR DESCRIPTION
This PR updates the CircleCI config the v2 orb. This has updated needed for changes in GEOSgcm_App and Baselibs