### PR TITLE
Change the GMI dry deposition resistance temperature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Reformatted the YAML ExtData file, zero diff
-- Changed Be and Pb species to use GOCART convection (instead of MOIST), and GOCART approach (instead of GMI) for settling, dry dep and wet removal
+- Changed Be and Pb species to use GOCART convection (instead of MOIST), and GOCART approach (instead of GMI) for settling, dry dep and wet removal; these are now the default settings
+- Updated the resistance temperature dependence in the GMI DryDep routine
 
 ### Fixed
 

--- a/DryDepositionGmiMod.F90
+++ b/DryDepositionGmiMod.F90
@@ -630,10 +630,14 @@ CONTAINS
 !       temperatures below -18 C, so at colder temperatures, hold the
 !       resistance fixed.
 !       -----------------------------------------------------------------
-
-        rt = 1000.0d0 * Exp (-tempc1 - 4.0d0)
-
-        if (tempc1 < -18.0d0) rt = 1.2d9
+!
+!       rt = 1000.0d0 * Exp (-tempc1 - 4.0d0)
+!
+!       if (tempc1 < -18.0d0) rt = 1.2d9
+! LDO - Change to Zhang et al. 2003 resistance temperature dependence 
+        rt = 1.0d0
+        if (tempc1 < -1.0d0) rt = Exp (0.2d0*(-1.0d0 - tempc1))
+        rt = Min (rt, 2.0d0)
 
 
 !       ------------------------------------------------------------------


### PR DESCRIPTION
Copy the approach used in the GMI module; this improves Dry Deposition.
Currently, the species affected by dry deposition (i.e. Be, Pb) use the GOCART approach by default, not the GMI approach.
So this PR is zero-diff.