### PR TITLE
Dev to Main - June 2024

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,11 @@
 version: 2.1
 
 # Anchors in case we need to override the defaults from the orb
-#baselibs_version: &baselibs_version v7.14.0
-#bcs_version: &bcs_version v11.1.0
+#baselibs_version: &baselibs_version v7.17.0
+#bcs_version: &bcs_version v11.4.0
 
 orbs:
-  ci: geos-esm/circleci-tools@1
+  ci: geos-esm/circleci-tools@2
 
 workflows:
   build-test:
@@ -22,4 +22,34 @@ workflows:
           repo: GEOSgcm
           checkout_fixture: true
           mepodevelop: true
-          persist_workspace: false # Needs to be true to run fv3/gcm experiment, costs extra
+          persist_workspace: true # Needs to be true to run fv3/gcm experiment, costs extra
+
+      # Run AMIP GCM (1 hour, no ExtData)
+      - ci/run_gcm:
+          name: run-GCM-on-<< matrix.compiler >>
+          context:
+            - docker-hub-creds
+          matrix:
+            parameters:
+              compiler: [gfortran, ifort]
+          requires:
+            - build-GEOSgcm-on-<< matrix.compiler >>
+          repo: GEOSgcm
+          #baselibs_version: *baselibs_version
+          #bcs_version: *bcs_version
+
+      # Run Coupled GCM (1 hour, no ExtData)
+      - ci/run_gcm:
+          name: run-coupled-GCM-on-<< matrix.compiler >>
+          context:
+            - docker-hub-creds
+          matrix:
+            parameters:
+              compiler: [gfortran, ifort]
+          requires:
+            - build-GEOSgcm-on-<< matrix.compiler >>
+          repo: GEOSgcm
+          #baselibs_version: *baselibs_version
+          #bcs_version: *bcs_version
+          gcm_ocean_type: MOM6
+          change_layout: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
-# Anchors to prevent forgetting to update a version
-baselibs_version: &baselibs_version v7.13.0
-bcs_version: &bcs_version v11.00.0
+# Anchors in case we need to override the defaults from the orb
+#baselibs_version: &baselibs_version v7.14.0
+#bcs_version: &bcs_version v11.1.0
 
 orbs:
   ci: geos-esm/circleci-tools@1
@@ -18,7 +18,7 @@ workflows:
           matrix:
             parameters:
               compiler: [gfortran, ifort]
-          baselibs_version: *baselibs_version
+          #baselibs_version: *baselibs_version
           repo: GEOSgcm
           checkout_fixture: true
           mepodevelop: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 ### Changed
+
+- Reformatted the YAML ExtData file, zero diff
+
 ### Fixed
 ### Removed
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reformatted the YAML ExtData file, zero diff
 
 ### Fixed
+
+- Bug fix for GMI dry deposition, related to solar zenith angle
+
 ### Removed
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Update CI to use Baselibs default from the CircleCI orb
+- Update CI to use v2 orb
 - Bug fix for GMI dry deposition, related to solar zenith angle
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
+- Added a timer for each tracer, and the option of 'strict' timing (with a barrier before and after each tracer)
+
 ### Changed
 
 - Reformatted the YAML ExtData file, zero diff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Reformatted the YAML ExtData file, zero diff
-- Changed Be and Pb species to use GOCART convection (instead of MOIST), and GOCART approach (instead of GMI) for settling, dry dep and wet removal
+- Changed Be and Pb species to use GOCART convection (instead of MOIST), and GOCART approach (instead of GMI) for settling, dry dep and wet removal; these are now the default settings
+- Updated the resistance temperature dependence in the GMI DryDep routine
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Reformatted the YAML ExtData file, zero diff
+- Changed Be and Pb species to use GOCART convection (instead of MOIST), and GOCART approach (instead of GMI) for settling, dry dep and wet removal
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+### Changed
+### Fixed
+### Removed
+### Deprecated
+
+## [1.2.0] - 2024-06-20
 
 ### Added
 
@@ -22,9 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update CI to use v2 orb
 - Bug fix for GMI dry deposition, related to solar zenith angle
 
-
-### Removed
-### Deprecated
 
 ## [1.1.0] - 2023-06-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Changed
 ### Fixed
+
+- Update CI to use Baselibs default from the CircleCI orb
+
 ### Removed
 ### Deprecated
 

--- a/DryDepositionGmiMod.F90
+++ b/DryDepositionGmiMod.F90
@@ -630,10 +630,14 @@ CONTAINS
 !       temperatures below -18 C, so at colder temperatures, hold the
 !       resistance fixed.
 !       -----------------------------------------------------------------
-
-        rt = 1000.0d0 * Exp (-tempc1 - 4.0d0)
-
-        if (tempc1 < -18.0d0) rt = 1.2d9
+!
+!       rt = 1000.0d0 * Exp (-tempc1 - 4.0d0)
+!
+!       if (tempc1 < -18.0d0) rt = 1.2d9
+! LDO - Change to Zhang et al. 2003 resistance temperature dependence 
+        rt = 1.0d0
+        if (tempc1 < -1.0d0) rt = Exp (0.2d0*(-1.0d0 - tempc1))
+        rt = Min (rt, 2.0d0)
 
 
 !       ------------------------------------------------------------------

--- a/TR_ExtData.yaml
+++ b/TR_ExtData.yaml
@@ -1,215 +1,76 @@
 Collections:
-  TR_ARCTAS.region_mask.x540_y361.2008.nc:
-    template: ExtData/AeroCom/sfc/ARCTAS.region_mask.x540_y361.2008.nc
-  TR_CMIP6.CO_anthro.x720_y360_t12.nc4:
-    template: ExtData/g5chem/sfc/CMIP6.CO_anthro.x720_y360_t12.nc4
-  TR_CMIP6.CO_anthronmvoc.x720_y360_t12.nc4:
-    template: ExtData/g5chem/sfc/CMIP6.CO_anthronmvoc.x720_y360_t12.nc4
-  TR_CMIP6.CO_bb.x1440_y720_t12.nc4:
-    template: ExtData/g5chem/sfc/CMIP6.CO_bb.x1440_y720_t12.nc4
-  TR_CMIP6.CO_bbnmvoc.x1440_y720_t12.nc4:
-    template: ExtData/g5chem/sfc/CMIP6.CO_bbnmvoc.x1440_y720_t12.nc4
-  TR_EDGAR_IPCC.sf6.x144_y91_t12.2008.nc:
-    template: ExtData/g5chem/sfc/SF6/EDGAR_IPCC.sf6.x144_y91_t12.2008.nc
-  TR_HTAP2.region_map_modified_coastlines.x720_y360.nc4:
-    template: ExtData/g5chem/sfc/HTAP2.region_map_modified_coastlines.x720_y360.nc4
-  TR_Koch.beryllium.x144_y91_z72.nc4:
-    template: ExtData/g5chem/L72/Koch.beryllium.x144_y91_z72.nc4
-  TR_M2G.CO_bionmvoc.x720_y360_t12.nc4:
-    template: ExtData/g5chem/sfc/M2G.CO_bionmvoc.x720_y360_t12.nc4
-  TR_RADON.region_mask.x540_y361.2001.nc:
-    template: ExtData/g5chem/sfc/RADON.region_mask.x540_y361.2001.nc
-  TR_RETRO.co.x144_y91_t12.2000.nc:
-    template: ExtData/g5chem/sfc/RETRO.co.x144_y91_t12.2000.nc
-  TR_Rn222.Zhang_Liu_et_al.x720_y360_t12.nc4:
-    template: ExtData/g5chem/sfc/Rn222.Zhang_Liu_et_al.x720_y360_t12.nc4
-  TR_lai_x720_y360_v72_t12_2008.nc:
-    template: ExtData/g5chem/sfc/LAI/lai_x720_y360_v72_t12_2008.nc
-  TR_unity.x144_y91.nc:
-    template: ExtData/g5chem/sfc/unity.x144_y91.nc
-  TR_veg_fraction_x720_y360_t12_2008.nc:
-    template: ExtData/g5chem/sfc/LAI/veg_fraction_x720_y360_t12_2008.nc
+  TR.CMIP6_CO_ANTHRO.emis.monthly_clim:        { template: ExtData/g5chem/sfc/CMIP6.CO_anthro.x720_y360_t12.nc4                  }
+  TR.CMIP6_CO_ANTHRO-NMVOC.emis.monthly_clim:  { template: ExtData/g5chem/sfc/CMIP6.CO_anthronmvoc.x720_y360_t12.nc4             }
+  TR.CMIP6_CO_BB.emis.monthly_clim:            { template: ExtData/g5chem/sfc/CMIP6.CO_bb.x1440_y720_t12.nc4                     }
+  TR.CMIP6_CO_BB-NMVOC.emis.monthly_clim:      { template: ExtData/g5chem/sfc/CMIP6.CO_bbnmvoc.x1440_y720_t12.nc4                }
+  TR.M2G_CO_BIO-NMVOC.emis.monthly_clim:       { template: ExtData/g5chem/sfc/M2G.CO_bionmvoc.x720_y360_t12.nc4                  }
+  TR.EDGAR-IPCC_SF6.emis.monthly_clim:         { template: ExtData/g5chem/sfc/SF6/EDGAR_IPCC.sf6.x144_y91_t12.2008.nc            }
+  TR.Koch_beryllium.tend.annual_clim:          { template: ExtData/g5chem/L72/Koch.beryllium.x144_y91_z72.nc4                    }
+  TR.CO.emis.monthly_clim:                     { template: ExtData/g5chem/sfc/RETRO.co.x144_y91_t12.2000.nc                      }
+  TR.Rn222_Zhang-Liu.emis.monthly_clim:        { template: ExtData/g5chem/sfc/Rn222.Zhang_Liu_et_al.x720_y360_t12.nc4            }
+# TR.Rn222_Jacob.emis.annual_clim:             { template: ExtData/g5chem/sfc/Rn222_Jacob_et_al.x540_y361.nc                     }
+  TR.LAI.monthly_clim:                         { template: ExtData/g5chem/sfc/LAI/lai_x720_y360_v72_t12_2008.nc                  }
+  TR.VEG_FRAC.monthly_clim:                    { template: ExtData/g5chem/sfc/LAI/veg_fraction_x720_y360_t12_2008.nc             }
+  TR.MASK_ARCTAS:                              { template: ExtData/AeroCom/sfc/ARCTAS.region_mask.x540_y361.2008.nc              }
+  TR.MASK_RADON:                               { template: ExtData/g5chem/sfc/RADON.region_mask.x540_y361.2001.nc                }
+  TR.MASK_HTAP2:                               { template: ExtData/g5chem/sfc/HTAP2.region_map_modified_coastlines.x720_y360.nc4 }
+  TR.UNITY:                                    { template: ExtData/g5chem/sfc/unity.x144_y91.nc                                  }
 
 Samplings:
-  TR_sample_0:
-    extrapolation: clim
-    update_frequency: PT24H
-    update_offset: PT12H
-    update_reference_time: '0'
-  TR_sample_1:
-    extrapolation: persist_closest
-  TR_sample_2:
-    update_frequency: PT24H
-    update_offset: PT12H
-    update_reference_time: '0'
+  TR.daily:      { time_interpolation: true , update_frequency: PT24H,  update_offset: PT12H,  update_reference_time: '0', extrapolation: none            }
+  TR.daily_wrap: { time_interpolation: true , update_frequency: PT24H,  update_offset: PT12H,  update_reference_time: '0', extrapolation: clim            }
+  TR.constant:   { time_interpolation: false,                                                                              extrapolation: persist_closest }
 
 Exports:
-  CO_CMIP6_ANTHRO:
-    collection: TR_CMIP6.CO_anthro.x720_y360_t12.nc4
-    regrid: CONSERVE
-    sample: TR_sample_0
-    variable: co_anthro
-  CO_CMIP6_ANTHRO_NMVOC:
-    collection: TR_CMIP6.CO_anthronmvoc.x720_y360_t12.nc4
-    regrid: CONSERVE
-    sample: TR_sample_0
-    variable: co_anthronmvoc
-  CO_CMIP6_BB:
-    collection: TR_CMIP6.CO_bb.x1440_y720_t12.nc4
-    regrid: CONSERVE
-    sample: TR_sample_0
-    variable: co_bb
-  CO_CMIP6_BB_NMVOC:
-    collection: TR_CMIP6.CO_bbnmvoc.x1440_y720_t12.nc4
-    regrid: CONSERVE
-    sample: TR_sample_0
-    variable: co_bbnmvoc
-  CO_M2G_BIOG_NMVOC:
-    collection: TR_M2G.CO_bionmvoc.x720_y360_t12.nc4
-    regrid: CONSERVE
-    sample: TR_sample_0
-    variable: co_bionmvoc
-  DD_OX:
-    collection: /dev/null
-  HTAP2_REGION_MASK_COASTAL_MOD:
-    collection: TR_HTAP2.region_map_modified_coastlines.x720_y360.nc4
-    regrid: VOTE
-    sample: TR_sample_1
-    variable: region_map
-  OX_TR:
-    collection: /dev/null
-  SRC_2D_CH3I:
-    collection: TR_unity.x144_y91.nc
-    linear_transformation:
-      - 0.0
-      - 2.35694e-21
-    sample: TR_sample_1
-    variable: unity_array
-  SRC_2D_CO_25:
-    collection: TR_RETRO.co.x144_y91_t12.2000.nc
-    regrid: CONSERVE
-    sample: TR_sample_0
-    variable: emission_flux
-  SRC_2D_CO_50:
-    collection: TR_RETRO.co.x144_y91_t12.2000.nc
-    regrid: CONSERVE
-    sample: TR_sample_0
-    variable: emission_flux
-  SRC_2D_CO_50_ea:
-    collection: TR_RETRO.co.x144_y91_t12.2000.nc
-    regrid: CONSERVE
-    sample: TR_sample_0
-    variable: emission_flux
-  SRC_2D_CO_50_eu:
-    collection: TR_RETRO.co.x144_y91_t12.2000.nc
-    regrid: CONSERVE
-    sample: TR_sample_0
-    variable: emission_flux
-  SRC_2D_CO_50_na:
-    collection: TR_RETRO.co.x144_y91_t12.2000.nc
-    regrid: CONSERVE
-    sample: TR_sample_0
-    variable: emission_flux
-  SRC_2D_CO_50_sa:
-    collection: TR_RETRO.co.x144_y91_t12.2000.nc
-    regrid: CONSERVE
-    sample: TR_sample_0
-    variable: emission_flux
-  SRC_2D_Rn222:
-    collection: TR_Rn222.Zhang_Liu_et_al.x720_y360_t12.nc4
-    sample: TR_sample_0
-    variable: rnemis
-  SRC_2D_SF6:
-    collection: TR_EDGAR_IPCC.sf6.x144_y91_t12.2008.nc
-    regrid: CONSERVE
-    sample: TR_sample_0
-    variable: sf6
-  SRC_3D_Be10:
-    collection: TR_Koch.beryllium.x144_y91_z72.nc4
-    regrid: CONSERVE
-    sample: TR_sample_1
-    variable: koch_be10_mr
-  SRC_3D_Be10s:
-    collection: TR_Koch.beryllium.x144_y91_z72.nc4
-    regrid: CONSERVE
-    sample: TR_sample_1
-    variable: koch_be10_mr
-  SRC_3D_Be7:
-    collection: TR_Koch.beryllium.x144_y91_z72.nc4
-    regrid: CONSERVE
-    sample: TR_sample_1
-    variable: koch_be7_mr
-  SRC_3D_Be7s:
-    collection: TR_Koch.beryllium.x144_y91_z72.nc4
-    regrid: CONSERVE
-    sample: TR_sample_1
-    variable: koch_be7_mr
-  TR_LAI_FRAC:
-    collection: TR_lai_x720_y360_v72_t12_2008.nc
-    sample: TR_sample_0
-    variable: LAI_FRAC
-  TR_VEG_FRAC:
-    collection: TR_veg_fraction_x720_y360_t12_2008.nc
-    sample: TR_sample_0
-    variable: VEG_FRAC
-  TR_regionMask:
-    collection: TR_RADON.region_mask.x540_y361.2001.nc
-    regrid: VOTE
-    sample: TR_sample_1
-    variable: REGION_MASK
-  TR_regionMask2:
-    collection: TR_ARCTAS.region_mask.x540_y361.2008.nc
-    regrid: VOTE
-    sample: TR_sample_1
-    variable: REGION_MASK
-  stOX_loss:
-    collection: /dev/null
+  # CO as specified for CCMI  (regional sources specified as lat/lon boxes):
+  SRC_2D_CO_25:                  { variable: emission_flux,   collection: TR.CO.emis.monthly_clim,                    regrid: CONSERVE, sample: TR.daily_wrap }
+  SRC_2D_CO_50:                  { variable: emission_flux,   collection: TR.CO.emis.monthly_clim,                    regrid: CONSERVE, sample: TR.daily_wrap }
+  SRC_2D_CO_50_ea:               { variable: emission_flux,   collection: TR.CO.emis.monthly_clim,                    regrid: CONSERVE, sample: TR.daily_wrap }
+  SRC_2D_CO_50_eu:               { variable: emission_flux,   collection: TR.CO.emis.monthly_clim,                    regrid: CONSERVE, sample: TR.daily_wrap }
+  SRC_2D_CO_50_na:               { variable: emission_flux,   collection: TR.CO.emis.monthly_clim,                    regrid: CONSERVE, sample: TR.daily_wrap }
+  SRC_2D_CO_50_sa:               { variable: emission_flux,   collection: TR.CO.emis.monthly_clim,                    regrid: CONSERVE, sample: TR.daily_wrap }
+  # CO as specified for CMIP6 (these components are combined in the DerivedExports section)  (regional sources done using HTAP2 Mask file):
+  CO_CMIP6_ANTHRO:               { variable: co_anthro,       collection: TR.CMIP6_CO_ANTHRO.emis.monthly_clim,       regrid: CONSERVE, sample: TR.daily_wrap }
+  CO_CMIP6_ANTHRO_NMVOC:         { variable: co_anthronmvoc,  collection: TR.CMIP6_CO_ANTHRO-NMVOC.emis.monthly_clim, regrid: CONSERVE, sample: TR.daily_wrap }
+  CO_CMIP6_BB:                   { variable: co_bb,           collection: TR.CMIP6_CO_BB.emis.monthly_clim,           regrid: CONSERVE, sample: TR.daily_wrap }
+  CO_CMIP6_BB_NMVOC:             { variable: co_bbnmvoc,      collection: TR.CMIP6_CO_BB-NMVOC.emis.monthly_clim,     regrid: CONSERVE, sample: TR.daily_wrap }
+  CO_M2G_BIOG_NMVOC:             { variable: co_bionmvoc,     collection: TR.M2G_CO_BIO-NMVOC.emis.monthly_clim,      regrid: CONSERVE, sample: TR.daily_wrap }
+  #
+  SRC_2D_SF6:                    { variable: sf6,             collection: TR.EDGAR-IPCC_SF6.emis.monthly_clim,        regrid: CONSERVE, sample: TR.daily_wrap }
+  SRC_2D_Rn222:                  { variable: rnemis,          collection: TR.Rn222_Zhang-Liu.emis.monthly_clim,       regrid: BILINEAR, sample: TR.daily_wrap }
+# SRC_2D_Rn222:  prior version   { variable: Rn222_emissions, collection: TR.Rn222_Jacob.emis.annual_clim,            regrid: CONSERVE, sample: TR.constant   }
+  SRC_2D_CH3I:                   { variable: unity_array,     collection: TR.UNITY,       linear_transformation: [ 0.0, 2.35694e-21 ],  sample: TR.constant   }
+# SRC_2D_CH3I:   simpler         {                            collection: /dev/null,      linear_transformation: [ 2.35694e-21, 0.0 ]                         }
+  SRC_3D_Be7:                    { variable: koch_be7_mr,     collection: TR.Koch_beryllium.tend.annual_clim,         regrid: CONSERVE, sample: TR.constant   }
+  SRC_3D_Be7s:                   { variable: koch_be7_mr,     collection: TR.Koch_beryllium.tend.annual_clim,         regrid: CONSERVE, sample: TR.constant   }
+  SRC_3D_Be10:                   { variable: koch_be10_mr,    collection: TR.Koch_beryllium.tend.annual_clim,         regrid: CONSERVE, sample: TR.constant   }
+  SRC_3D_Be10s:                  { variable: koch_be10_mr,    collection: TR.Koch_beryllium.tend.annual_clim,         regrid: CONSERVE, sample: TR.constant   }
+  # For tracers using dry deposition:
+  TR_LAI_FRAC:                   { variable: LAI_FRAC,        collection: TR.LAI.monthly_clim,                        regrid: BILINEAR, sample: TR.daily_wrap }
+  TR_VEG_FRAC:                   { variable: VEG_FRAC,        collection: TR.VEG_FRAC.monthly_clim,                   regrid: BILINEAR, sample: TR.daily_wrap }
+  # Masks:
+  TR_regionMask:                 { variable: REGION_MASK,     collection: TR.MASK_RADON,                              regrid: VOTE,     sample: TR.constant   }
+  TR_regionMask2:                { variable: REGION_MASK,     collection: TR.MASK_ARCTAS,                             regrid: VOTE,     sample: TR.constant   }
+  HTAP2_REGION_MASK_COASTAL_MOD: { variable: region_map,      collection: TR.MASK_HTAP2,                              regrid: VOTE,     sample: TR.constant   }
+  # In case GMI is not running (stOX uses these):
+  DD_OX:                         {                            collection: /dev/null                                                                           }
+  OX_TR:                         {                            collection: /dev/null                                                                           }
+  stOX_loss:                     {                            collection: /dev/null                                                                           }
 
 Derived:
-  SRC_2D_CO_ANZ:
-    function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC
-    sample: TR_sample_2
-  SRC_2D_CO_ARC:
-    function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC
-    sample: TR_sample_2
-  SRC_2D_CO_CAM:
-    function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC
-    sample: TR_sample_2
-  SRC_2D_CO_CAS:
-    function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC
-    sample: TR_sample_2
-  SRC_2D_CO_EAS:
-    function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC
-    sample: TR_sample_2
-  SRC_2D_CO_EUR:
-    function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC
-    sample: TR_sample_2
-  SRC_2D_CO_GLB:
-    function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC
-    sample: TR_sample_2
-  SRC_2D_CO_MDE:
-    function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC
-    sample: TR_sample_2
-  SRC_2D_CO_NAF:
-    function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC
-    sample: TR_sample_2
-  SRC_2D_CO_NAM:
-    function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC
-    sample: TR_sample_2
-  SRC_2D_CO_RAF:
-    function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC
-    sample: TR_sample_2
-  SRC_2D_CO_RBU:
-    function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC
-    sample: TR_sample_2
-  SRC_2D_CO_SAM:
-    function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC
-    sample: TR_sample_2
-  SRC_2D_CO_SAS:
-    function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC
-    sample: TR_sample_2
-  SRC_2D_CO_SEA:
-    function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC
-    sample: TR_sample_2
-
+  SRC_2D_CO_ANZ: { function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC, sample: TR.daily }
+  SRC_2D_CO_ARC: { function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC, sample: TR.daily }
+  SRC_2D_CO_CAM: { function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC, sample: TR.daily }
+  SRC_2D_CO_CAS: { function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC, sample: TR.daily }
+  SRC_2D_CO_EAS: { function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC, sample: TR.daily }
+  SRC_2D_CO_EUR: { function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC, sample: TR.daily }
+  SRC_2D_CO_GLB: { function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC, sample: TR.daily }
+  SRC_2D_CO_MDE: { function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC, sample: TR.daily }
+  SRC_2D_CO_NAF: { function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC, sample: TR.daily }
+  SRC_2D_CO_NAM: { function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC, sample: TR.daily }
+  SRC_2D_CO_RAF: { function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC, sample: TR.daily }
+  SRC_2D_CO_RBU: { function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC, sample: TR.daily }
+  SRC_2D_CO_SAM: { function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC, sample: TR.daily }
+  SRC_2D_CO_SAS: { function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC, sample: TR.daily }
+  SRC_2D_CO_SEA: { function: CO_CMIP6_ANTHRO+CO_CMIP6_ANTHRO_NMVOC+CO_CMIP6_BB+CO_CMIP6_BB_NMVOC+CO_M2G_BIOG_NMVOC, sample: TR.daily }
 

--- a/TR_GridComp---Be10.rc
+++ b/TR_GridComp---Be10.rc
@@ -37,44 +37,44 @@
 
 # DEPOSITION
 # ---------------------------
-  GMI_dry_deposition: TRUE
-# (as in gmi_aerosol.h)
-  GMI_aerosol_density: 1769.e0
-  GMI_effective_radius: 0.1000e-6
-  GMI_c1: 0.4809e0
-  GMI_c2: 3.082e0
-  GMI_c3: 3.110e-11
-  GMI_c4: -1.428e0
-  GMI_hstar_dry:           0.0e0  # as in setkin_depos.h
-  GMI_delH_298_over_R_dry: 0.0e0  # as in setkin_depos.h
+#  GMI_dry_deposition: TRUE
+## (as in gmi_aerosol.h)
+#  GMI_aerosol_density: 1769.e0
+#  GMI_effective_radius: 0.1000e-6
+#  GMI_c1: 0.4809e0
+#  GMI_c2: 3.082e0
+#  GMI_c3: 3.110e-11
+#  GMI_c4: -1.428e0
+#  GMI_hstar_dry:           0.0e0  # as in setkin_depos.h
+#  GMI_delH_298_over_R_dry: 0.0e0  # as in setkin_depos.h
+#
+## NOTE: must provide for GMI dry dep and wet dep
+#  mw: 10.0
+#  GMI_treat_as_aerosol: TRUE     # as in setkin_depos.h
+#  GMI_f0:                  0.0e0  # as in setkin_depos.h  (oxidize)
+#
+#  GMI_wet_removal: TRUE
+#  GMI_rel_scav_eff:        1.0e0  # as in gmi_aerosol.h
+#  GMI_retention_eff:       0.0e0  # as in setkin_depos.h
+#  GMI_treat_as_h2o2:    FALSE
+#  GMI_treat_as_hno3:    FALSE
+#  GMI_hstar_wet:           0.0e0  # as in setkin_depos.h
+#  GMI_delH_298_over_R_wet: 0.0e0  # as in setkin_depos.h
 
-# NOTE: must provide for GMI dry dep and wet dep
   mw: 10.0
-  GMI_treat_as_aerosol: TRUE     # as in setkin_depos.h
-  GMI_f0:                  0.0e0  # as in setkin_depos.h  (oxidize)
 
-  GMI_wet_removal: TRUE
-  GMI_rel_scav_eff:        1.0e0  # as in gmi_aerosol.h
-  GMI_retention_eff:       0.0e0  # as in setkin_depos.h
-  GMI_treat_as_h2o2:    FALSE
-  GMI_treat_as_hno3:    FALSE
-  GMI_hstar_wet:           0.0e0  # as in setkin_depos.h
-  GMI_delH_298_over_R_wet: 0.0e0  # as in setkin_depos.h
+  GOCART_wet_removal: TRUE
+  GOCART_convection:  TRUE
 
-# mw: 10.0
+  GOCART_species:     Be10
+  GOCART_aero_flag:   TRUE
+  GOCART_fscav:       0.4    # (what value should be used?)  scavenging efficiency in convective updrafts [km-1]
+  GOCART_fwet:        1.0    # (what value should be used?)  large-scale wet removal efficiency [fraction]
 
-# GOCART_wet_removal: TRUE
-# GOCART_convection:  FALSE
+  GOCART_settling:    FALSE
+  GOCART_radius:      0.35e-6  # (what value should be used?)  radius for settling [m]
+  GOCART_rho_p:       1800.0   # (what value should be used?)  density for setting [kg m-3]
+  GOCART_rh_effect:   0        # (what value should be used?)  Flag for RH effects  (0=none, 1=Fitzgerald, 2=Gerber, 3=Ammonium Sulfate, 4=Petters and Kreidenweis)
 
-# GOCART_species:     Be10
-# GOCART_aero_flag:   TRUE
-# GOCART_fscav:       0.4    # (what value should be used?)  scavenging efficiency in convective updrafts [km-1]
-# GOCART_fwet:        1.0    # (what value should be used?)  large-scale wet removal efficiency [fraction]
-
-# GOCART_settling:    FALSE
-# GOCART_radius:      0.35e-6  # (what value should be used?)  radius for settling [m]
-# GOCART_rho_p:       1800.0   # (what value should be used?)  density for setting [kg m-3]
-# GOCART_rh_effect:   0        # (what value should be used?)  Flag for RH effects  (0=none, 1=Fitzgerald, 2=Gerber, 3=Ammonium Sulfate, 4=Petters and Kreidenweis)
-
-# GOCART_dry_deposition:    TRUE
+  GOCART_dry_deposition:    TRUE
 

--- a/TR_GridComp---Be10s.rc
+++ b/TR_GridComp---Be10s.rc
@@ -37,44 +37,44 @@
 
 # DEPOSITION
 # ---------------------------
-  GMI_dry_deposition: TRUE
-# (as in gmi_aerosol.h)
-  GMI_aerosol_density: 1769.e0
-  GMI_effective_radius: 0.1000e-6
-  GMI_c1: 0.4809e0
-  GMI_c2: 3.082e0
-  GMI_c3: 3.110e-11
-  GMI_c4: -1.428e0
-  GMI_hstar_dry:           0.0e0  # as in setkin_depos.h
-  GMI_delH_298_over_R_dry: 0.0e0  # as in setkin_depos.h
+#  GMI_dry_deposition: TRUE
+## (as in gmi_aerosol.h)
+#  GMI_aerosol_density: 1769.e0
+#  GMI_effective_radius: 0.1000e-6
+#  GMI_c1: 0.4809e0
+#  GMI_c2: 3.082e0
+#  GMI_c3: 3.110e-11
+#  GMI_c4: -1.428e0
+#  GMI_hstar_dry:           0.0e0  # as in setkin_depos.h
+#  GMI_delH_298_over_R_dry: 0.0e0  # as in setkin_depos.h
+#
+## NOTE: must provide for GMI dry dep and wet dep
+#  mw: 10.0
+#  GMI_treat_as_aerosol: TRUE     # as in setkin_depos.h
+#  GMI_f0:                  0.0e0  # as in setkin_depos.h  (oxidize)
+#
+#  GMI_wet_removal: TRUE
+#  GMI_rel_scav_eff:        1.0e0  # as in gmi_aerosol.h
+#  GMI_retention_eff:       0.0e0  # as in setkin_depos.h
+#  GMI_treat_as_h2o2:    FALSE
+#  GMI_treat_as_hno3:    FALSE
+#  GMI_hstar_wet:           0.0e0  # as in setkin_depos.h
+#  GMI_delH_298_over_R_wet: 0.0e0  # as in setkin_depos.h
 
-# NOTE: must provide for GMI dry dep and wet dep
   mw: 10.0
-  GMI_treat_as_aerosol: TRUE     # as in setkin_depos.h
-  GMI_f0:                  0.0e0  # as in setkin_depos.h  (oxidize)
 
-  GMI_wet_removal: TRUE
-  GMI_rel_scav_eff:        1.0e0  # as in gmi_aerosol.h
-  GMI_retention_eff:       0.0e0  # as in setkin_depos.h
-  GMI_treat_as_h2o2:    FALSE
-  GMI_treat_as_hno3:    FALSE
-  GMI_hstar_wet:           0.0e0  # as in setkin_depos.h
-  GMI_delH_298_over_R_wet: 0.0e0  # as in setkin_depos.h
+  GOCART_wet_removal: TRUE
+  GOCART_convection:  TRUE
 
-# mw: 10.0
+  GOCART_species:     Be10s
+  GOCART_aero_flag:   TRUE
+  GOCART_fscav:       0.4    # (what value should be used?)  scavenging efficiency in convective updrafts [km-1]
+  GOCART_fwet:        1.0    # (what value should be used?)  large-scale wet removal efficiency [fraction]
 
-# GOCART_wet_removal: TRUE
-# GOCART_convection:  FALSE
+  GOCART_settling:    FALSE
+  GOCART_radius:      0.35e-6  # (what value should be used?)  radius for settling [m]
+  GOCART_rho_p:       1800.0   # (what value should be used?)  density for setting [kg m-3]
+  GOCART_rh_effect:   0        # (what value should be used?)  Flag for RH effects  (0=none, 1=Fitzgerald, 2=Gerber, 3=Ammonium Sulfate, 4=Petters and Kreidenweis)
 
-# GOCART_species:     Be10s
-# GOCART_aero_flag:   TRUE
-# GOCART_fscav:       0.4    # (what value should be used?)  scavenging efficiency in convective updrafts [km-1]
-# GOCART_fwet:        1.0    # (what value should be used?)  large-scale wet removal efficiency [fraction]
-
-# GOCART_settling:    FALSE
-# GOCART_radius:      0.35e-6  # (what value should be used?)  radius for settling [m]
-# GOCART_rho_p:       1800.0   # (what value should be used?)  density for setting [kg m-3]
-# GOCART_rh_effect:   0        # (what value should be used?)  Flag for RH effects  (0=none, 1=Fitzgerald, 2=Gerber, 3=Ammonium Sulfate, 4=Petters and Kreidenweis)
-
-# GOCART_dry_deposition:    TRUE
+  GOCART_dry_deposition:    TRUE
 

--- a/TR_GridComp---Be7.rc
+++ b/TR_GridComp---Be7.rc
@@ -37,44 +37,44 @@
 
 # DEPOSITION
 # ---------------------------
-  GMI_dry_deposition: TRUE
-# (as in gmi_aerosol.h)
-  GMI_aerosol_density: 1769.e0
-  GMI_effective_radius: 0.1000e-6
-  GMI_c1: 0.4809e0
-  GMI_c2: 3.082e0
-  GMI_c3: 3.110e-11
-  GMI_c4: -1.428e0
-  GMI_hstar_dry:           0.0e0  # as in setkin_depos.h
-  GMI_delH_298_over_R_dry: 0.0e0  # as in setkin_depos.h
+#  GMI_dry_deposition: TRUE
+## (as in gmi_aerosol.h)
+#  GMI_aerosol_density: 1769.e0
+#  GMI_effective_radius: 0.1000e-6
+#  GMI_c1: 0.4809e0
+#  GMI_c2: 3.082e0
+#  GMI_c3: 3.110e-11
+#  GMI_c4: -1.428e0
+#  GMI_hstar_dry:           0.0e0  # as in setkin_depos.h
+#  GMI_delH_298_over_R_dry: 0.0e0  # as in setkin_depos.h
+#
+## NOTE: must provide for GMI dry dep and wet dep
+#  mw: 7.0
+#  GMI_treat_as_aerosol: TRUE     # as in setkin_depos.h
+#  GMI_f0:                  0.0e0  # as in setkin_depos.h  (oxidize)
+#
+#  GMI_wet_removal: TRUE
+#  GMI_rel_scav_eff:        1.0e0  # as in gmi_aerosol.h
+#  GMI_retention_eff:       0.0e0  # as in setkin_depos.h
+#  GMI_treat_as_h2o2:    FALSE
+#  GMI_treat_as_hno3:    FALSE
+#  GMI_hstar_wet:           0.0e0  # as in setkin_depos.h
+#  GMI_delH_298_over_R_wet: 0.0e0  # as in setkin_depos.h
 
-# NOTE: must provide for GMI dry dep and wet dep
   mw: 7.0
-  GMI_treat_as_aerosol: TRUE     # as in setkin_depos.h
-  GMI_f0:                  0.0e0  # as in setkin_depos.h  (oxidize)
 
-  GMI_wet_removal: TRUE
-  GMI_rel_scav_eff:        1.0e0  # as in gmi_aerosol.h
-  GMI_retention_eff:       0.0e0  # as in setkin_depos.h
-  GMI_treat_as_h2o2:    FALSE
-  GMI_treat_as_hno3:    FALSE
-  GMI_hstar_wet:           0.0e0  # as in setkin_depos.h
-  GMI_delH_298_over_R_wet: 0.0e0  # as in setkin_depos.h
+  GOCART_wet_removal: TRUE
+  GOCART_convection:  TRUE
 
-# mw: 7.0
+  GOCART_species:     Be7
+  GOCART_aero_flag:   TRUE
+  GOCART_fscav:       0.4    # (what value should be used?)  scavenging efficiency in convective updrafts [km-1]
+  GOCART_fwet:        1.0    # (what value should be used?)  large-scale wet removal efficiency [fraction]
 
-# GOCART_wet_removal: TRUE
-# GOCART_convection:  FALSE
+  GOCART_settling:    FALSE
+  GOCART_radius:      0.35e-6  # (what value should be used?)  radius for settling [m]
+  GOCART_rho_p:       1800.0   # (what value should be used?)  density for setting [kg m-3]
+  GOCART_rh_effect:   0        # (what value should be used?)  Flag for RH effects  (0=none, 1=Fitzgerald, 2=Gerber, 3=Ammonium Sulfate, 4=Petters and Kreidenweis)
 
-# GOCART_species:     Be7
-# GOCART_aero_flag:   TRUE
-# GOCART_fscav:       0.4    # (what value should be used?)  scavenging efficiency in convective updrafts [km-1]
-# GOCART_fwet:        1.0    # (what value should be used?)  large-scale wet removal efficiency [fraction]
-
-# GOCART_settling:    FALSE
-# GOCART_radius:      0.35e-6  # (what value should be used?)  radius for settling [m]
-# GOCART_rho_p:       1800.0   # (what value should be used?)  density for setting [kg m-3]
-# GOCART_rh_effect:   0        # (what value should be used?)  Flag for RH effects  (0=none, 1=Fitzgerald, 2=Gerber, 3=Ammonium Sulfate, 4=Petters and Kreidenweis)
-
-# GOCART_dry_deposition:    TRUE
+  GOCART_dry_deposition:    TRUE
 

--- a/TR_GridComp---Be7s.rc
+++ b/TR_GridComp---Be7s.rc
@@ -37,44 +37,44 @@
 
 # DEPOSITION
 # ---------------------------
-  GMI_dry_deposition: TRUE
-# (as in gmi_aerosol.h)
-  GMI_aerosol_density: 1769.e0
-  GMI_effective_radius: 0.1000e-6
-  GMI_c1: 0.4809e0
-  GMI_c2: 3.082e0
-  GMI_c3: 3.110e-11
-  GMI_c4: -1.428e0
-  GMI_hstar_dry:           0.0e0  # as in setkin_depos.h
-  GMI_delH_298_over_R_dry: 0.0e0  # as in setkin_depos.h
+#  GMI_dry_deposition: TRUE
+## (as in gmi_aerosol.h)
+#  GMI_aerosol_density: 1769.e0
+#  GMI_effective_radius: 0.1000e-6
+#  GMI_c1: 0.4809e0
+#  GMI_c2: 3.082e0
+#  GMI_c3: 3.110e-11
+#  GMI_c4: -1.428e0
+#  GMI_hstar_dry:           0.0e0  # as in setkin_depos.h
+#  GMI_delH_298_over_R_dry: 0.0e0  # as in setkin_depos.h
+#
+## NOTE: must provide for GMI dry dep and wet dep
+#  mw: 7.0
+#  GMI_treat_as_aerosol: TRUE     # as in setkin_depos.h
+#  GMI_f0:                  0.0e0  # as in setkin_depos.h  (oxidize)
+#
+#  GMI_wet_removal: TRUE
+#  GMI_rel_scav_eff:        1.0e0  # as in gmi_aerosol.h
+#  GMI_retention_eff:       0.0e0  # as in setkin_depos.h
+#  GMI_treat_as_h2o2:    FALSE
+#  GMI_treat_as_hno3:    FALSE
+#  GMI_hstar_wet:           0.0e0  # as in setkin_depos.h
+#  GMI_delH_298_over_R_wet: 0.0e0  # as in setkin_depos.h
 
-# NOTE: must provide for GMI dry dep and wet dep
   mw: 7.0
-  GMI_treat_as_aerosol: TRUE     # as in setkin_depos.h
-  GMI_f0:                  0.0e0  # as in setkin_depos.h  (oxidize)
 
-  GMI_wet_removal: TRUE
-  GMI_rel_scav_eff:        1.0e0  # as in gmi_aerosol.h
-  GMI_retention_eff:       0.0e0  # as in setkin_depos.h
-  GMI_treat_as_h2o2:    FALSE
-  GMI_treat_as_hno3:    FALSE
-  GMI_hstar_wet:           0.0e0  # as in setkin_depos.h
-  GMI_delH_298_over_R_wet: 0.0e0  # as in setkin_depos.h
+  GOCART_wet_removal: TRUE
+  GOCART_convection:  TRUE
 
-# mw: 7.0
+  GOCART_species:     Be7s
+  GOCART_aero_flag:   TRUE
+  GOCART_fscav:       0.4    # (what value should be used?)  scavenging efficiency in convective updrafts [km-1]
+  GOCART_fwet:        1.0    # (what value should be used?)  large-scale wet removal efficiency [fraction]
 
-# GOCART_wet_removal: TRUE
-# GOCART_convection:  FALSE
+  GOCART_settling:    FALSE
+  GOCART_radius:      0.35e-6  # (what value should be used?)  radius for settling [m]
+  GOCART_rho_p:       1800.0   # (what value should be used?)  density for setting [kg m-3]
+  GOCART_rh_effect:   0        # (what value should be used?)  Flag for RH effects  (0=none, 1=Fitzgerald, 2=Gerber, 3=Ammonium Sulfate, 4=Petters and Kreidenweis)
 
-# GOCART_species:     Be7s
-# GOCART_aero_flag:   TRUE
-# GOCART_fscav:       0.4    # (what value should be used?)  scavenging efficiency in convective updrafts [km-1]
-# GOCART_fwet:        1.0    # (what value should be used?)  large-scale wet removal efficiency [fraction]
-
-# GOCART_settling:    FALSE
-# GOCART_radius:      0.35e-6  # (what value should be used?)  radius for settling [m]
-# GOCART_rho_p:       1800.0   # (what value should be used?)  density for setting [kg m-3]
-# GOCART_rh_effect:   0        # (what value should be used?)  Flag for RH effects  (0=none, 1=Fitzgerald, 2=Gerber, 3=Ammonium Sulfate, 4=Petters and Kreidenweis)
-
-# GOCART_dry_deposition:    TRUE
+  GOCART_dry_deposition:    TRUE
 

--- a/TR_GridComp---Pb210.rc
+++ b/TR_GridComp---Pb210.rc
@@ -35,44 +35,44 @@
 
 # DEPOSITION
 # ---------------------------
-  GMI_dry_deposition: TRUE
-# (as in gmi_aerosol.h)
-  GMI_aerosol_density: 1769.e0
-  GMI_effective_radius: 0.3417e-6
-  GMI_c1: 0.4809e0
-  GMI_c2: 3.082e0
-  GMI_c3: 3.110e-11
-  GMI_c4: -1.428e0
-  GMI_hstar_dry:           0.0e0  # as in setkin_depos.h
-  GMI_delH_298_over_R_dry: 0.0e0  # as in setkin_depos.h
-
-# NOTE: must provide for GMI dry dep and wet dep
-  mw: 210
-  GMI_treat_as_aerosol: TRUE     # as in setkin_depos.h
-  GMI_f0:                  0.0e0  # as in setkin_depos.h  (oxidize)
-
-  GMI_wet_removal: TRUE
-  GMI_rel_scav_eff:        1.0e0  # as in gmi_aerosol.h
-  GMI_retention_eff:       0.0e0  # as in setkin_depos.h
-  GMI_treat_as_h2o2:    FALSE
-  GMI_treat_as_hno3:    FALSE
-  GMI_hstar_wet:           0.0e0  # as in setkin_depos.h
-  GMI_delH_298_over_R_wet: 0.0e0  # as in setkin_depos.h
+#  GMI_dry_deposition: TRUE
+## (as in gmi_aerosol.h)
+#  GMI_aerosol_density: 1769.e0
+#  GMI_effective_radius: 0.3417e-6
+#  GMI_c1: 0.4809e0
+#  GMI_c2: 3.082e0
+#  GMI_c3: 3.110e-11
+#  GMI_c4: -1.428e0
+#  GMI_hstar_dry:           0.0e0  # as in setkin_depos.h
+#  GMI_delH_298_over_R_dry: 0.0e0  # as in setkin_depos.h
+#
+## NOTE: must provide for GMI dry dep and wet dep
+#  mw: 210
+#  GMI_treat_as_aerosol: TRUE     # as in setkin_depos.h
+#  GMI_f0:                  0.0e0  # as in setkin_depos.h  (oxidize)
+#
+#  GMI_wet_removal: TRUE
+#  GMI_rel_scav_eff:        1.0e0  # as in gmi_aerosol.h
+#  GMI_retention_eff:       0.0e0  # as in setkin_depos.h
+#  GMI_treat_as_h2o2:    FALSE
+#  GMI_treat_as_hno3:    FALSE
+#  GMI_hstar_wet:           0.0e0  # as in setkin_depos.h
+#  GMI_delH_298_over_R_wet: 0.0e0  # as in setkin_depos.h
 
 # NOTE: must provide mw for dry dep and wet dep
-# mw: 210
+  mw: 210
 
-# GOCART_wet_removal: TRUE
-# GOCART_convection:  FALSE
+  GOCART_wet_removal: TRUE
+  GOCART_convection:  TRUE
 
-# GOCART_species:     Pb210
-# GOCART_aero_flag:   TRUE
-# GOCART_fscav:       0.4    # (what value should be used?)  scavenging efficiency in convective updrafts [km-1]
-# GOCART_fwet:        1.0    # (what value should be used?)  large-scale wet removal efficiency [fraction]
+  GOCART_species:     Pb210
+  GOCART_aero_flag:   TRUE
+  GOCART_fscav:       0.4    # (what value should be used?)  scavenging efficiency in convective updrafts [km-1]
+  GOCART_fwet:        1.0    # (what value should be used?)  large-scale wet removal efficiency [fraction]
 
-# GOCART_settling:    FALSE
-# GOCART_radius:      0.35e-6  # (what value should be used?)  radius for settling [m]
-# GOCART_rho_p:       1800.0   # (what value should be used?)  density for setting [kg m-3]
-# GOCART_rh_effect:   0        # (what value should be used?)  Flag for RH effects  (0=none, 1=Fitzgerald, 2=Gerber, 3=Ammonium Sulfate, 4=Petters and Kreidenweis)
+  GOCART_settling:    FALSE
+  GOCART_radius:      0.35e-6  # (what value should be used?)  radius for settling [m]
+  GOCART_rho_p:       1800.0   # (what value should be used?)  density for setting [kg m-3]
+  GOCART_rh_effect:   0        # (what value should be used?)  Flag for RH effects  (0=none, 1=Fitzgerald, 2=Gerber, 3=Ammonium Sulfate, 4=Petters and Kreidenweis)
 
-# GOCART_dry_deposition:    TRUE
+  GOCART_dry_deposition:    TRUE

--- a/TR_GridComp---Pb210s.rc
+++ b/TR_GridComp---Pb210s.rc
@@ -35,45 +35,45 @@
 
 # DEPOSITION
 # ---------------------------
-  GMI_dry_deposition: TRUE
-# (as in gmi_aerosol.h)
-  GMI_aerosol_density: 1769.e0
-  GMI_effective_radius: 0.3417e-6
-  GMI_c1: 0.4809e0
-  GMI_c2: 3.082e0
-  GMI_c3: 3.110e-11
-  GMI_c4: -1.428e0
-  GMI_hstar_dry:           0.0e0  # as in setkin_depos.h
-  GMI_delH_298_over_R_dry: 0.0e0  # as in setkin_depos.h
-
-# NOTE: must provide for GMI dry dep and wet dep
-  mw: 210
-  GMI_treat_as_aerosol: TRUE     # as in setkin_depos.h
-  GMI_f0:                  0.0e0  # as in setkin_depos.h  (oxidize)
-
-  GMI_wet_removal: TRUE
-  GMI_rel_scav_eff:        1.0e0  # as in gmi_aerosol.h
-  GMI_retention_eff:       0.0e0  # as in setkin_depos.h
-  GMI_treat_as_h2o2:    FALSE
-  GMI_treat_as_hno3:    FALSE
-  GMI_hstar_wet:           0.0e0  # as in setkin_depos.h
-  GMI_delH_298_over_R_wet: 0.0e0  # as in setkin_depos.h
+#  GMI_dry_deposition: TRUE
+## (as in gmi_aerosol.h)
+#  GMI_aerosol_density: 1769.e0
+#  GMI_effective_radius: 0.3417e-6
+#  GMI_c1: 0.4809e0
+#  GMI_c2: 3.082e0
+#  GMI_c3: 3.110e-11
+#  GMI_c4: -1.428e0
+#  GMI_hstar_dry:           0.0e0  # as in setkin_depos.h
+#  GMI_delH_298_over_R_dry: 0.0e0  # as in setkin_depos.h
+#
+## NOTE: must provide for GMI dry dep and wet dep
+#  mw: 210
+#  GMI_treat_as_aerosol: TRUE     # as in setkin_depos.h
+#  GMI_f0:                  0.0e0  # as in setkin_depos.h  (oxidize)
+#
+#  GMI_wet_removal: TRUE
+#  GMI_rel_scav_eff:        1.0e0  # as in gmi_aerosol.h
+#  GMI_retention_eff:       0.0e0  # as in setkin_depos.h
+#  GMI_treat_as_h2o2:    FALSE
+#  GMI_treat_as_hno3:    FALSE
+#  GMI_hstar_wet:           0.0e0  # as in setkin_depos.h
+#  GMI_delH_298_over_R_wet: 0.0e0  # as in setkin_depos.h
 
 # NOTE: must provide mw for dry dep and wet dep
-# mw: 210
+  mw: 210
 
-# GOCART_wet_removal: TRUE
-# GOCART_convection:  FALSE
+  GOCART_wet_removal: TRUE
+  GOCART_convection:  TRUE
 
-# GOCART_species:     Pb210s
-# GOCART_aero_flag:   TRUE
-# GOCART_fscav:       0.4    # (what value should be used?)  scavenging efficiency in convective updrafts [km-1]
-# GOCART_fwet:        1.0    # (what value should be used?)  large-scale wet removal efficiency [fraction]
+  GOCART_species:     Pb210s
+  GOCART_aero_flag:   TRUE
+  GOCART_fscav:       0.4    # (what value should be used?)  scavenging efficiency in convective updrafts [km-1]
+  GOCART_fwet:        1.0    # (what value should be used?)  large-scale wet removal efficiency [fraction]
 
-# GOCART_settling:    FALSE
-# GOCART_radius:      0.35e-6  # (what value should be used?)  radius for settling [m]
-# GOCART_rho_p:       1800.0   # (what value should be used?)  density for setting [kg m-3]
-# GOCART_rh_effect:   0        # (what value should be used?)  Flag for RH effects  (0=none, 1=Fitzgerald, 2=Gerber, 3=Ammonium Sulfate, 4=Petters and Kreidenweis)
+  GOCART_settling:    FALSE
+  GOCART_radius:      0.35e-6  # (what value should be used?)  radius for settling [m]
+  GOCART_rho_p:       1800.0   # (what value should be used?)  density for setting [kg m-3]
+  GOCART_rh_effect:   0        # (what value should be used?)  Flag for RH effects  (0=none, 1=Fitzgerald, 2=Gerber, 3=Ammonium Sulfate, 4=Petters and Kreidenweis)
 
-# GOCART_dry_deposition:    TRUE
+  GOCART_dry_deposition:    TRUE
 

--- a/TR_GridComp.rc
+++ b/TR_GridComp.rc
@@ -1,0 +1,8 @@
+#
+# Resource file for TR (Passive Tracer Gridded Component)
+
+# Use only for diagnostic timing tests:
+# --------------------------------------------------
+ strict_tracer_timing: .FALSE.
+
+

--- a/TR_GridCompMod.F90
+++ b/TR_GridCompMod.F90
@@ -291,6 +291,9 @@
 
      integer                         :: pet               ! ID of the persistent execution thread
 
+     LOGICAL                         :: strict_tracer_timing ! Call a barrier before and after each tracer is run
+                                                             ! Only use this to test timings, not operationally
+
   END TYPE TR_State
 
 ! Hook for the ESMF
@@ -362,6 +365,7 @@ CONTAINS
     logical                        :: gocart_conv
     logical                        :: lai_needed
     logical                        :: stOX_loss_needed
+    type (ESMF_Config)             :: myCF
 
     character(len=ESMF_MAXSTR), allocatable   :: str_array(:)  ! to hold unique ExtData entries
     integer                        :: s_count                  ! number of entries in str_array
@@ -450,6 +454,16 @@ CONTAINS
 !   --------------------------
     call ESMF_UserCompSetInternalState ( GC, 'TR_STATE', wrap, STATUS )
     VERIFY_(STATUS)
+
+!   Read resource settings
+!   ----------------------
+    myCF = ESMF_ConfigCreate(__RC__)
+    call   ESMF_ConfigLoadFile    (myCF, 'TR_GridComp.rc', __RC__ )
+    call   ESMF_ConfigGetAttribute(myCF, myState%strict_tracer_timing, Default=.FALSE., Label="strict_tracer_timing:", __RC__ )
+    call   ESMF_ConfigDestroy     (myCF, __RC__)
+
+    IF(MAPL_AM_I_ROOT()) PRINT *, TRIM(Iam)//": strict_tracer_timing =", myState%strict_tracer_timing
+
   
 !                         ------------------
 !                         MAPL Data Services
@@ -1246,12 +1260,6 @@ CONTAINS
 !   VERIFY_(STATUS)
 
 
-!   Set the Profiling timers
-!   ------------------------
-    CALL MAPL_TimerAdd(GC, NAME="INITIALIZE", __RC__ )
-    CALL MAPL_TimerAdd(GC, NAME="RUN",        __RC__ )
-    CALL MAPL_TimerAdd(GC, NAME="FINALIZE",   __RC__ )
-
 !   Generic Set Services
 !   --------------------
     call MAPL_GenericSetServices ( GC, __RC__ )
@@ -1610,6 +1618,8 @@ CONTAINS
 
     logical                       :: verbose=.FALSE.
 
+    type (ESMF_VM)                :: VM
+
 
 ! For NTYPE
 # include "gmi_emiss_constants.h"
@@ -1739,13 +1749,26 @@ CONTAINS
 
    END IF
 
+   IF ( myState%strict_tracer_timing ) THEN
+     call ESMF_VMGetCurrent ( VM=VM, __RC__ )
+     call ESMF_VMBarrier(VM, __RC__ )
+   END IF
+
 
 !  Run each tracer (source and sink)
 !  ---------------------------------
    do n = 1, k%tr_count
 
+     call MAPL_TimerOn( genState, trim(myState%spec(n)%name))
+
      call TR_run_tracer_ ( myState%pet, myState%kit, myState%spec, myState%spec(n), myState%qa, &
                            GRID, IMPORT, EXPORT,  nymd, nhms, cdt, GC, CLOCK, __RC__ )
+
+     IF ( myState%strict_tracer_timing ) THEN
+       call ESMF_VMBarrier(VM, __RC__ )
+     END IF 
+
+     call MAPL_TimerOff(genState, trim(myState%spec(n)%name))
 
    end do
 

--- a/TR_GridCompMod.F90
+++ b/TR_GridCompMod.F90
@@ -4669,8 +4669,11 @@ CONTAINS
               radswg(:,:) = swndsrf(:,:)       ! w m^{-2}
     frictionVelocity(:,:) =   ustar(:,:)       ! m s^{-1}
 
+! SZA (don't forget to take the cosine)
+! ---
    call compute_SZA ( GC=gc, CLOCK=clock, tdt=cdt, label='TR:'//TRIM(spec%name), &
                       SZA=cosSolarZenithAngle, __RC__ )
+   cosSolarZenithAngle = COS( cosSolarZenithAngle * MAPL_DEGREES_TO_RADIANS )
 
    IF ( associated(drydep_tend_2d) ) then
      allocate( snapshot_2d( i1:i2, j1:j2), __STAT__)


### PR DESCRIPTION
About to release v1.2.0
This PR is non-zero-diff for the tracers in Be and Pb families;  all other tracers are zero diff, and of course **none of these changes affects the main GEOS model.**

* Updated CI to use v2 orb
* Fixed bug in GMI drydep, related to solar zenith angle
* Reformatted the ExtData YAML file
* Changed the default settings for Be and Pb species, to use GOCART (Chem_Shared) convection instead of MOIST, and GOCART approach for settling, drydep and wet removal instead of GMI approach
* Updated the resistance temperature dependence in the GMI DryDep routine, to reflect Zhang 2003; no tracers currently run this section of code, but it's here for consistency w/ GMI
* Added a timer for each tracer, and the option of 'strict' timing