### PR TITLE
Prep for v1.2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,11 @@
 version: 2.1
 
 # Anchors in case we need to override the defaults from the orb
-#baselibs_version: &baselibs_version v7.17.0
-#bcs_version: &bcs_version v11.4.0
+#baselibs_version: &baselibs_version v7.27.0
+#bcs_version: &bcs_version v11.6.0
 
 orbs:
-  ci: geos-esm/circleci-tools@2
+  ci: geos-esm/circleci-tools@4
 
 workflows:
   build-test:

--- a/.github/workflows/changelog-enforcer.yml
+++ b/.github/workflows/changelog-enforcer.yml
@@ -3,6 +3,10 @@ on:
   pull_request:
       types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   # Enforces the update of a changelog file on every pull request
   changelog:

--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -4,24 +4,28 @@ on:
   pull_request:
     types: [opened, labeled, unlabeled, edited, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   require-label:
     runs-on: ubuntu-latest
     steps:
-      - uses: mheap/github-action-required-labels@v3
+      - uses: mheap/github-action-required-labels@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           mode: minimum
           count: 1
-          labels: "0 diff,0 diff trivial,Non 0-diff,0 diff structural,0-diff trivial,Not 0-diff,0-diff,automatic,0-diff uncoupled"
+          labels: "0 diff,0 diff trivial,Non 0-diff,0 diff structural,0-diff trivial,Not 0-diff,0-diff,automatic,0-diff uncoupled,github_actions"
           add_comment: true
           message: "This PR is being prevented from merging because you have not added one of our required labels: {{ provided }}. Please add one so that the PR can be merged."
 
   blocking-label:
     runs-on: ubuntu-latest
     steps:
-      - uses: mheap/github-action-required-labels@v3
+      - uses: mheap/github-action-required-labels@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/validate_yaml_files.yml
+++ b/.github/workflows/validate_yaml_files.yml
@@ -15,7 +15,7 @@ jobs:
   validate-YAML:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.2.0
+      - uses: actions/checkout@v4
       - id: yaml-lint
         name: yaml-lint
         uses: ibiqlik/action-yamllint@v3
@@ -24,7 +24,7 @@ jobs:
           format: colored
           config_file: .yamllint.yml
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: yamllint-logfile

--- a/.github/workflows/validate_yaml_files.yml
+++ b/.github/workflows/validate_yaml_files.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
       types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 # This validation is equivalent to running on the command line:
 #   yamllint -d relaxed --no-warnings
 # and is controlled by the .yamllint.yml file
@@ -15,7 +19,11 @@ jobs:
   validate-YAML:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repo
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          filter: blob:none
       - id: yaml-lint
         name: yaml-lint
         uses: ibiqlik/action-yamllint@v3
@@ -24,7 +32,7 @@ jobs:
           format: colored
           config_file: .yamllint.yml
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: yamllint-logfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update GitHub actions to use v4
+- Added clarification to YAML ExtData file
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 ### Changed
+
+- Update GitHub actions to use v4
+
 ### Fixed
 ### Removed
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 ### Changed
+### Fixed
+### Removed
+### Deprecated
+
+## [1.2.1] - 2026-04-16
+
+### Changed
 
 - Update GitHub actions to use v4
 - Added clarification to YAML ExtData file
@@ -18,9 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- Removed references to w_c; requires Chem_Settling2 routine in Chem_Shared
+- Removed references to w_c; requires Chem_Settling2 routine in Chem_Shared (GEOSchem_GridComp v1.16.2)
 
-### Deprecated
 
 ## [1.2.0] - 2024-06-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update GitHub actions to use v4
 
 ### Fixed
+
+- Changed default SF6 emissions; instead of just repeating 2008 we now use 1969-2008 EDGAR values
+
 ### Removed
+
+- Removed references to w_c; requires Chem_Settling2 routine in Chem_Shared
+
 ### Deprecated
 
 ## [1.2.0] - 2024-06-20

--- a/TR_ExtData.yaml
+++ b/TR_ExtData.yaml
@@ -4,7 +4,7 @@ Collections:
   TR.CMIP6_CO_BB.emis.monthly_clim:            { template: ExtData/g5chem/sfc/CMIP6.CO_bb.x1440_y720_t12.nc4                     }
   TR.CMIP6_CO_BB-NMVOC.emis.monthly_clim:      { template: ExtData/g5chem/sfc/CMIP6.CO_bbnmvoc.x1440_y720_t12.nc4                }
   TR.M2G_CO_BIO-NMVOC.emis.monthly_clim:       { template: ExtData/g5chem/sfc/M2G.CO_bionmvoc.x720_y360_t12.nc4                  }
-  TR.EDGAR-IPCC_SF6.emis.monthly_clim:         { template: ExtData/g5chem/sfc/SF6/EDGAR_IPCC.sf6.x144_y91_t12.2008.nc            }
+  TR.EDGAR-IPCC_SF6.emis.monthly_clim:         { valid_range: "1969-01-15T00:00/2008-12-15T12:00", template: ExtData/g5chem/sfc/SF6/EDGAR_IPCC.sf6.x144_y91_t12.%y4.nc }
   TR.Koch_beryllium.tend.annual_clim:          { template: ExtData/g5chem/L72/Koch.beryllium.x144_y91_z72.nc4                    }
   TR.CO.emis.monthly_clim:                     { template: ExtData/g5chem/sfc/RETRO.co.x144_y91_t12.2000.nc                      }
   TR.Rn222_Zhang-Liu.emis.monthly_clim:        { template: ExtData/g5chem/sfc/Rn222.Zhang_Liu_et_al.x720_y360_t12.nc4            }

--- a/TR_ExtData.yaml
+++ b/TR_ExtData.yaml
@@ -1,10 +1,10 @@
 Collections:
+# Climatologies
   TR.CMIP6_CO_ANTHRO.emis.monthly_clim:        { template: ExtData/g5chem/sfc/CMIP6.CO_anthro.x720_y360_t12.nc4                  }
   TR.CMIP6_CO_ANTHRO-NMVOC.emis.monthly_clim:  { template: ExtData/g5chem/sfc/CMIP6.CO_anthronmvoc.x720_y360_t12.nc4             }
   TR.CMIP6_CO_BB.emis.monthly_clim:            { template: ExtData/g5chem/sfc/CMIP6.CO_bb.x1440_y720_t12.nc4                     }
   TR.CMIP6_CO_BB-NMVOC.emis.monthly_clim:      { template: ExtData/g5chem/sfc/CMIP6.CO_bbnmvoc.x1440_y720_t12.nc4                }
   TR.M2G_CO_BIO-NMVOC.emis.monthly_clim:       { template: ExtData/g5chem/sfc/M2G.CO_bionmvoc.x720_y360_t12.nc4                  }
-  TR.EDGAR-IPCC_SF6.emis.monthly_clim:         { valid_range: "1969-01-15T00:00/2008-12-15T12:00", template: ExtData/g5chem/sfc/SF6/EDGAR_IPCC.sf6.x144_y91_t12.%y4.nc }
   TR.Koch_beryllium.tend.annual_clim:          { template: ExtData/g5chem/L72/Koch.beryllium.x144_y91_z72.nc4                    }
   TR.CO.emis.monthly_clim:                     { template: ExtData/g5chem/sfc/RETRO.co.x144_y91_t12.2000.nc                      }
   TR.Rn222_Zhang-Liu.emis.monthly_clim:        { template: ExtData/g5chem/sfc/Rn222.Zhang_Liu_et_al.x720_y360_t12.nc4            }
@@ -15,6 +15,9 @@ Collections:
   TR.MASK_RADON:                               { template: ExtData/g5chem/sfc/RADON.region_mask.x540_y361.2001.nc                }
   TR.MASK_HTAP2:                               { template: ExtData/g5chem/sfc/HTAP2.region_map_modified_coastlines.x720_y360.nc4 }
   TR.UNITY:                                    { template: ExtData/g5chem/sfc/unity.x144_y91.nc                                  }
+
+# Time Series
+  TR.EDGAR-IPCC_SF6.emis.monthly.1969-2008:    { valid_range: "1969-01-15T00:00/2008-12-15T12:00", template: ExtData/g5chem/sfc/SF6/EDGAR_IPCC.sf6.x144_y91_t12.%y4.nc }
 
 Samplings:
   TR.daily:      { time_interpolation: true , update_frequency: PT24H,  update_offset: PT12H,  update_reference_time: '0', extrapolation: none            }
@@ -36,7 +39,7 @@ Exports:
   CO_CMIP6_BB_NMVOC:             { variable: co_bbnmvoc,      collection: TR.CMIP6_CO_BB-NMVOC.emis.monthly_clim,     regrid: CONSERVE, sample: TR.daily_wrap }
   CO_M2G_BIOG_NMVOC:             { variable: co_bionmvoc,     collection: TR.M2G_CO_BIO-NMVOC.emis.monthly_clim,      regrid: CONSERVE, sample: TR.daily_wrap }
   #
-  SRC_2D_SF6:                    { variable: sf6,             collection: TR.EDGAR-IPCC_SF6.emis.monthly_clim,        regrid: CONSERVE, sample: TR.daily_wrap }
+  SRC_2D_SF6:                    { variable: sf6,             collection: TR.EDGAR-IPCC_SF6.emis.monthly.1969-2008,   regrid: CONSERVE, sample: TR.daily_wrap }
   SRC_2D_Rn222:                  { variable: rnemis,          collection: TR.Rn222_Zhang-Liu.emis.monthly_clim,       regrid: BILINEAR, sample: TR.daily_wrap }
 # SRC_2D_Rn222:  prior version   { variable: Rn222_emissions, collection: TR.Rn222_Jacob.emis.annual_clim,            regrid: CONSERVE, sample: TR.constant   }
   SRC_2D_CH3I:                   { variable: unity_array,     collection: TR.UNITY,       linear_transformation: [ 0.0, 2.35694e-21 ],  sample: TR.constant   }

--- a/TR_GridCompMod.F90
+++ b/TR_GridCompMod.F90
@@ -34,7 +34,7 @@
 
    USE         WetRemovalMod,  ONLY: WetRemovalGOCART             ! in Chem_Shared
    USE         ConvectionMod,  ONLY: convection, set_vud          ! in Chem_Shared
-   USE      Chem_SettlingMod,  ONLY: Chem_Settling                ! in Chem_Shared
+   USE      Chem_SettlingMod,  ONLY: Chem_Settling2               ! in Chem_Shared
    USE      DryDepositionMod,  ONLY: DryDepositionGOCART          ! in Chem_Shared
 
    USE             VegLaiMod,  ONLY: Decode_Land_Types, Decode_XLAI  ! in Chem_Shared
@@ -99,7 +99,6 @@
     INTEGER                            :: i1,i2,j1,j2        ! local index bounds
     REAL*8, POINTER, DIMENSION(:,:)    :: lats  => NULL()    ! Latitudes in degrees
     REAL*8, POINTER, DIMENSION(:,:)    :: lons  => NULL()    ! Longitudes in degrees, 0 to 360
-    REAL                               :: ptop               ! top pressure in Pa
     ! Only if needed for Dry Deposition:
     INTEGER, POINTER, DIMENSION(:,:)   :: ireg  => NULL()    ! Land type counts
     INTEGER, POINTER, DIMENSION(:,:,:) :: iland => NULL()    ! Land types
@@ -1457,9 +1456,6 @@ CONTAINS
      k%lats = lats * DEGPRAD
      k%lons = lons * DEGPRAD
      WHERE ( k%lons < 0.0 ) k%lons = k%lons + 360.0d0
-
-!    Hardcode Ptop, just as for w_c 
-     k%ptop = 1.0  ! Pa
 
 !  Allocate storage for all of the Tracer Specs
 !  --------------------------------------------
@@ -5292,11 +5288,12 @@ CONTAINS
 
     integer :: i1, i2, j1, j2, km, n1, n2, nbins
     integer :: rhFlag
-    real,              pointer  :: tracer_radius(:), tracer_rho_p(:)
-    type(Chem_Array),  pointer  :: tracer_sedimentation(:)  ! EXPORT: Black Carbon Sedimentation
-    type(Chem_Bundle), pointer  :: w_c
+    real                        :: tracer_radius, tracer_rho_p
+    type(Chem_Array),  pointer  :: tracer_sedimentation     ! naming from BC GridComp
 
     real, pointer, dimension(:,:)   :: hsurf
+    real, pointer, dimension(:,:,:) :: delp
+    real, pointer, dimension(:,:,:) :: rh
 
     real*4, allocatable, dimension(:,:,:) :: snapshot
 
@@ -5316,17 +5313,6 @@ CONTAINS
     n2 = 1
     nbins = 1
 
-    ! w_c
-    ! Chem_Settling() is tightly coupled to the Chem_Bundle (w_c) approach.
-    ! The official way to create w_c is to call  Chem_BundleCreate_(), passing it a chemReg.
-    ! (see GOCART_GridCompMod.F90)
-    ! We simplify by allocating only the components that Chem_Settling() will use.
-    ! Only 1 element of qa, since we handle 1 tracer in this call
-    allocate( w_c, __STAT__ )
-    allocate( w_c%qa(1), __STAT__)
-
-    w_c%qa(1)%data3d => data3d
-
     if ( associated(tendency3d) .OR.  associated(tendency2d) ) then
       allocate( snapshot( i1:i2, j1:j2, 1:km), __STAT__)
       snapshot = data3d
@@ -5338,41 +5324,39 @@ CONTAINS
     call MAPL_GetPointer ( impChem, tmpu,     'T',        __RC__ )
     call MAPL_GetPointer ( impChem, rhoa,     'AIRDENS',  __RC__ )
     call MAPL_GetPointer ( impChem, hghte,    'ZLE',      __RC__ )
-    call MAPL_GetPointer ( impChem, w_c%delp, 'DELP',     __RC__ )
-    call MAPL_GetPointer ( impChem, w_c%rh,   'RH2',      __RC__ )
+    call MAPL_GetPointer ( impChem, delp,     'DELP',     __RC__ )
+    call MAPL_GetPointer ( impChem, rh,       'RH2',      __RC__ )
 
     hsurf => hghte(i1:i2,j1:j2,km) ! Recall: GEOS-5 has edges with k in [0,km]
 
-    allocate( tracer_radius(nbins), tracer_rho_p(nbins), tracer_sedimentation(nbins), __STAT__ )   ! nbins == 1
+    allocate( tracer_sedimentation, __STAT__ )
 
-    tracer_sedimentation(1)%data2d => NULL()   ! If you want the export, allocate data2d(i1:i2,j1:j2)
+    tracer_sedimentation%data2d => NULL()   ! If you want the export, allocate data2d(i1:i2,j1:j2)
 
-    tracer_radius(:) = spec%GOCART_radius     ! radius for settling [m]
-    tracer_rho_p(:)  = spec%GOCART_rho_p      ! density for setting [kg m-3]
+    tracer_radius    = spec%GOCART_radius     ! radius for settling [m]
+    tracer_rho_p     = spec%GOCART_rho_p      ! density for setting [kg m-3]
     rhFlag           = spec%GOCART_rh_effect  ! settle like dry particles (0) or options 1,2,3,4
 
-    call Chem_Settling ( i1, i2, j1, j2, km, n1, n2, nbins, rhFlag, &
-                         tracer_radius, tracer_rho_p, cdt, w_c, tmpu, rhoa, hsurf,    &
-                         hghte, tracer_sedimentation, rc )
-    VERIFY_(RC)
+    call Chem_Settling2 ( i1, i2, j1, j2, km, rhFlag, &
+                          tracer_radius, tracer_rho_p, cdt, delp, rh, tmpu, rhoa, hsurf,    &
+                          hghte, data3d, tracer_sedimentation, rc )
+    VERIFY_(rc)
 
     if ( associated(tendency3d) .OR.  associated(tendency2d) ) then
 
       if ( associated(tendency3d) ) then
-        tendency3d =     (data3d-snapshot) * w_c%delp / (MAPL_GRAV*cdt)
+        tendency3d =     (data3d-snapshot) * delp / (MAPL_GRAV*cdt)
       end if
 
       if ( associated(tendency2d) ) then
-        tendency2d = SUM((data3d-snapshot) * w_c%delp / (MAPL_GRAV*cdt), 3)
+        tendency2d = SUM((data3d-snapshot) * delp / (MAPL_GRAV*cdt), 3)
       end if
 
       deallocate( snapshot, __STAT__)
 
     end if
 
-    deallocate( tracer_radius, tracer_rho_p, tracer_sedimentation, __STAT__ )
-    deallocate( w_c%qa, __STAT__)
-    deallocate( w_c, __STAT__ )
+    deallocate( tracer_sedimentation, __STAT__ )
 
     RETURN_(ESMF_SUCCESS)
 


### PR DESCRIPTION
Change default SF6 emissions to be year-specific.  Since SF6 is not in the standard list of TR tracers, this PR is zero-diff.
Removed w_c (chemistry bundle) -- this update must be taken together with GEOSchem_GridComp v1.16.2 .
